### PR TITLE
app now starts up with the profile service and controller hosted serv…

### DIFF
--- a/DS4Windows.Client.Core/ApplicationStartup.cs
+++ b/DS4Windows.Client.Core/ApplicationStartup.cs
@@ -63,8 +63,15 @@ namespace DS4Windows.Client.Core
             where TViewModel : IViewModel
             where TView : IView
         {
+            host.Start();
             using (var scope = host.Services.CreateScope())
             {
+                var moduleRegistrars = scope.ServiceProvider.GetServices<IServiceRegistrar>();
+                foreach (var registrar in moduleRegistrars)
+                {
+                    registrar.Initialize(scope.ServiceProvider);
+                }
+
                 var viewModelFactory = scope.ServiceProvider.GetRequiredService<IViewModelFactory>();
                 var viewModel = viewModelFactory.Create<TViewModel, TView>();
                 if (viewModel.MainView is Window windowViewModel)

--- a/DS4Windows.Client.Core/DS4Windows.Client.Core.csproj
+++ b/DS4Windows.Client.Core/DS4Windows.Client.Core.csproj
@@ -28,8 +28,4 @@
     </PackageReference>
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\DS4Windows.Shared.Common\DS4Windows.Shared.Common.csproj" />
-  </ItemGroup>
-
 </Project>

--- a/DS4Windows.Client.Core/DependencyInjection/IServiceRegistrar.cs
+++ b/DS4Windows.Client.Core/DependencyInjection/IServiceRegistrar.cs
@@ -1,11 +1,13 @@
 ﻿using DS4Windows.Client.Core.ViewModel;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using System;
 
 namespace DS4Windows.Client.Core.DependencyInjection
 {
     public interface IServiceRegistrar
     {
         void ConfigureServices(IConfiguration configuration, IServiceCollection services);
+        void Initialize(IServiceProvider services);
     }
 }

--- a/DS4Windows.Client.Core/DependencyInjection/RegistrarDiscovery.cs
+++ b/DS4Windows.Client.Core/DependencyInjection/RegistrarDiscovery.cs
@@ -19,7 +19,7 @@ namespace DS4Windows.Client.Core.DependencyInjection
                 .Where(d =>
                 {
                     var fileName = Path.GetFileName(d);
-                    return fileName.StartsWith("DS4Windows.Client") && fileName.EndsWith(".dll");
+                    return fileName.StartsWith("DS4Win") && fileName.EndsWith(".dll");
                 })
                 .Select(d => Assembly.LoadFrom(d))
                 .ToList();
@@ -36,6 +36,7 @@ namespace DS4Windows.Client.Core.DependencyInjection
                 if (instance != null)
                 {
                     services.AddSingleton(type, instance);
+                    services.AddSingleton(typeof(IServiceRegistrar), instance);
                     instance.ConfigureServices(configuration, services);
                 }
             }

--- a/DS4Windows.Client.Core/Tracing/OpenTelemetryRegistrar.cs
+++ b/DS4Windows.Client.Core/Tracing/OpenTelemetryRegistrar.cs
@@ -1,11 +1,7 @@
 ﻿using DS4Windows.Client.Core.DependencyInjection;
-using DS4Windows.Shared.Common.Core;
-using DS4Windows.Shared.Common.Telemetry;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using OpenTelemetry;
-using OpenTelemetry.Resources;
-using OpenTelemetry.Trace;
+using System;
 
 namespace DS4Windows.Client.Core.Tracing
 {
@@ -13,11 +9,12 @@ namespace DS4Windows.Client.Core.Tracing
     {
         public void ConfigureServices(IConfiguration configuration, IServiceCollection services)
         {
-            if (bool.TryParse(configuration.GetSection("OpenTelemetry:IsTracingEnabled").Value, out var isEnabled) &&
+            /*if (bool.TryParse(configuration.GetSection("OpenTelemetry:IsTracingEnabled").Value, out var isEnabled) &&
                 isEnabled)
                 //
                 // Initialize OpenTelemetry
                 // 
+                //TODO: open telemetry keeps giving me problems, need to figure it out and fix it later
                 services.AddOpenTelemetryTracing(builder => builder
                     .SetSampler(new AlwaysOnSampler())
                     .SetResourceBuilder(ResourceBuilder.CreateDefault().AddService(Constants.ApplicationName))
@@ -26,7 +23,13 @@ namespace DS4Windows.Client.Core.Tracing
                     .AddSource(TracingSources.CommonAssemblyActivitySourceName)
                     .AddSource(TracingSources.ConfigurationApplicationAssemblyActivitySourceName)
                     .AddJaegerExporter(options => { options.ExportProcessorType = ExportProcessorType.Simple; })
+            
                 );
+            */
+        }
+
+        public void Initialize(IServiceProvider services)
+        {
         }
     }
 }

--- a/DS4Windows.Client.Core/ViewModel/ViewModelRegistrar.cs
+++ b/DS4Windows.Client.Core/ViewModel/ViewModelRegistrar.cs
@@ -15,5 +15,9 @@ namespace DS4Windows.Client.Core.ViewModel
         {
             services.AddSingleton<IViewModelFactory, ViewModelFactory>();
         }
+
+        public void Initialize(IServiceProvider services)
+        {
+        }
     }
 }

--- a/DS4Windows.Client.Modules/Controllers/ControllersModuleRegistrar.cs
+++ b/DS4Windows.Client.Modules/Controllers/ControllersModuleRegistrar.cs
@@ -2,6 +2,7 @@
 using DS4Windows.Client.Core.ViewModel;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using System;
 
 namespace DS4Windows.Client.Modules.Controllers
 {
@@ -11,6 +12,10 @@ namespace DS4Windows.Client.Modules.Controllers
         {
             services.AddSingletons<ControllersViewModel>(typeof(IControllersViewModel), typeof(INavigationTabViewModel));
             services.AddSingleton<IControllersView, ControllersView>();
+        }
+
+        public void Initialize(IServiceProvider services)
+        {
         }
     }
 }

--- a/DS4Windows.Client.Modules/Main/MainModuleRegistrar.cs
+++ b/DS4Windows.Client.Modules/Main/MainModuleRegistrar.cs
@@ -1,7 +1,7 @@
 ﻿using DS4Windows.Client.Core.DependencyInjection;
-using DS4Windows.Client.Core.ViewModel;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using System;
 
 namespace DS4Windows.Client.Modules.Main
 {
@@ -11,6 +11,10 @@ namespace DS4Windows.Client.Modules.Main
         {
             services.AddSingleton<IMainView, MainWindow>();
             services.AddSingleton<IMainViewModel, MainWindowViewModel>();
+        }
+
+        public void Initialize(IServiceProvider services)
+        {
         }
     }
 }

--- a/DS4Windows.Client.Modules/Profiles/ProfilesModuleRegistrar.cs
+++ b/DS4Windows.Client.Modules/Profiles/ProfilesModuleRegistrar.cs
@@ -2,6 +2,7 @@
 using DS4Windows.Client.Core.ViewModel;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using System;
 
 namespace DS4Windows.Client.Modules.Profiles
 {
@@ -11,6 +12,10 @@ namespace DS4Windows.Client.Modules.Profiles
         {
             services.AddSingletons<ProfilesViewModel>(typeof(IProfilesViewModel), typeof(INavigationTabViewModel));
             services.AddSingleton<IProfilesView, ProfilesView>();
+        }
+
+        public void Initialize(IServiceProvider services)
+        {
         }
     }
 }

--- a/DS4Windows.Shared.Common/CommonRegistrar.cs
+++ b/DS4Windows.Shared.Common/CommonRegistrar.cs
@@ -1,17 +1,20 @@
 ﻿using DS4Windows.Client.Core.DependencyInjection;
-using DS4Windows.Client.Core.ViewModel;
+using DS4Windows.Shared.Common.Services;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
 
-namespace DS4Windows.Client.Modules.Settings
+namespace DS4Windows.Shared.Common
 {
-    public class SettingsModuleRegistrar : IServiceRegistrar
+    public class CommonRegistrar : IServiceRegistrar
     {
         public void ConfigureServices(IConfiguration configuration, IServiceCollection services)
         {
-            services.AddSingletons<SettingsViewModel>(typeof(ISettingsViewModel), typeof(INavigationTabViewModel));
-            services.AddSingleton<ISettingsView, SettingsView>();
+            services.AddSingleton<IGlobalStateService, GlobalStateService>();
         }
 
         public void Initialize(IServiceProvider services)

--- a/DS4Windows.Shared.Common/DS4Windows.Shared.Common.csproj
+++ b/DS4Windows.Shared.Common/DS4Windows.Shared.Common.csproj
@@ -22,7 +22,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="OpenTelemetry" Version="1.1.0" />
     <PackageReference Include="PropertyChanged.Fody" Version="3.4.0" PrivateAssets="all" ExcludeAssets="runtime" />
     <PackageReference Include="ConfigureAwait.Fody" Version="3.3.1">
       <PrivateAssets>all</PrivateAssets>
@@ -37,5 +36,9 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
     <PackageReference Include="PInvoke.Kernel32" Version="0.7.104" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DS4Windows.Client.Core\DS4Windows.Client.Core.csproj" />
   </ItemGroup>
 </Project>

--- a/DS4Windows.Shared.Configuration.Application/CoofnigurationRegistrar.cs
+++ b/DS4Windows.Shared.Configuration.Application/CoofnigurationRegistrar.cs
@@ -1,17 +1,20 @@
 ﻿using DS4Windows.Client.Core.DependencyInjection;
-using DS4Windows.Client.Core.ViewModel;
+using DS4Windows.Shared.Configuration.Application.Services;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
 
-namespace DS4Windows.Client.Modules.Settings
+namespace DS4Windows.Shared.Configuration.Application
 {
-    public class SettingsModuleRegistrar : IServiceRegistrar
+    public class CoofnigurationRegistrar : IServiceRegistrar
     {
         public void ConfigureServices(IConfiguration configuration, IServiceCollection services)
         {
-            services.AddSingletons<SettingsViewModel>(typeof(ISettingsViewModel), typeof(INavigationTabViewModel));
-            services.AddSingleton<ISettingsView, SettingsView>();
+            services.AddSingleton<IAppSettingsService, AppSettingsService>();
         }
 
         public void Initialize(IServiceProvider services)

--- a/DS4Windows.Shared.Configuration.Application/DS4Windows.Shared.Configuration.Application.csproj
+++ b/DS4Windows.Shared.Configuration.Application/DS4Windows.Shared.Configuration.Application.csproj
@@ -11,7 +11,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="OpenTelemetry" Version="1.1.0" />
     <PackageReference Include="PropertyChanged.Fody" Version="3.4.0" PrivateAssets="all" ExcludeAssets="runtime" />
     <PackageReference Include="ConfigureAwait.Fody" Version="3.3.1">
       <PrivateAssets>all</PrivateAssets>

--- a/DS4Windows.Shared.Configuration.Profiles/DS4Windows.Shared.Configuration.Profiles.csproj
+++ b/DS4Windows.Shared.Configuration.Profiles/DS4Windows.Shared.Configuration.Profiles.csproj
@@ -11,7 +11,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="OpenTelemetry" Version="1.1.0" />
     <PackageReference Include="PropertyChanged.Fody" Version="3.4.0" PrivateAssets="all" ExcludeAssets="runtime" />
     <PackageReference Include="ConfigureAwait.Fody" Version="3.3.1">
       <PrivateAssets>all</PrivateAssets>
@@ -28,6 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\DS4Windows.Client.Core\DS4Windows.Client.Core.csproj" />
     <ProjectReference Include="..\DS4Windows.Shared.Common\DS4Windows.Shared.Common.csproj" />
     <ProjectReference Include="..\DS4Windows.Shared.Configuration.Application\DS4Windows.Shared.Configuration.Application.csproj" />
   </ItemGroup>

--- a/DS4Windows.Shared.Configuration.Profiles/ProfilesRegistrar.cs
+++ b/DS4Windows.Shared.Configuration.Profiles/ProfilesRegistrar.cs
@@ -15,7 +15,6 @@ namespace DS4Windows.Shared.Configuration.Profiles
 
         public void Initialize(IServiceProvider services)
         {
-            services.GetRequiredService<IProfilesService>().Initialize();
         }
     }
 }

--- a/DS4Windows.Shared.Configuration.Profiles/ProfilesRegistrar.cs
+++ b/DS4Windows.Shared.Configuration.Profiles/ProfilesRegistrar.cs
@@ -1,21 +1,21 @@
 ﻿using DS4Windows.Client.Core.DependencyInjection;
-using DS4Windows.Client.Core.ViewModel;
+using DS4Windows.Shared.Configuration.Profiles.Services;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 
-namespace DS4Windows.Client.Modules.Settings
+namespace DS4Windows.Shared.Configuration.Profiles
 {
-    public class SettingsModuleRegistrar : IServiceRegistrar
+    public class ProfilesRegistrar : IServiceRegistrar
     {
         public void ConfigureServices(IConfiguration configuration, IServiceCollection services)
         {
-            services.AddSingletons<SettingsViewModel>(typeof(ISettingsViewModel), typeof(INavigationTabViewModel));
-            services.AddSingleton<ISettingsView, SettingsView>();
+            services.AddSingleton<IProfilesService, ProfilesService>();
         }
 
         public void Initialize(IServiceProvider services)
         {
+            services.GetRequiredService<IProfilesService>().Initialize();
         }
     }
 }

--- a/DS4Windows.Shared.Devices/DS4Windows.Shared.Devices.csproj
+++ b/DS4Windows.Shared.Devices/DS4Windows.Shared.Devices.csproj
@@ -11,7 +11,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="OpenTelemetry" Version="1.1.0" />
       <PackageReference Include="PropertyChanged.Fody" Version="3.4.0" PrivateAssets="all" ExcludeAssets="runtime" />
     <PackageReference Include="ConfigureAwait.Fody" Version="3.3.1">
       <PrivateAssets>all</PrivateAssets>
@@ -34,6 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\DS4Windows.Client.Core\DS4Windows.Client.Core.csproj" />
     <ProjectReference Include="..\DS4Windows.Shared.Common\DS4Windows.Shared.Common.csproj" />
     <ProjectReference Include="..\DS4Windows.Shared.Configuration.Profiles\DS4Windows.Shared.Configuration.Profiles.csproj" />
   </ItemGroup>

--- a/DS4Windows.Shared.Devices/DevicesRegistrar.cs
+++ b/DS4Windows.Shared.Devices/DevicesRegistrar.cs
@@ -1,0 +1,35 @@
+﻿using DS4Windows.Client.Core.DependencyInjection;
+using DS4Windows.Shared.Devices.HID;
+using DS4Windows.Shared.Devices.HostedServices;
+using DS4Windows.Shared.Devices.Services;
+using DS4Windows.Shared.Devices.Util;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Threading;
+
+namespace DS4Windows.Shared.Devices
+{
+    public class DevicesRegistrar : IServiceRegistrar
+    {
+        public void ConfigureServices(IConfiguration configuration, IServiceCollection services)
+        {
+            services.AddSingleton<IControllerManagerService, ControllerManagerService>();
+            services.AddSingleton<IHidHideControlService, HidHideControlService>();
+            services.AddSingleton<IHidDeviceEnumeratorService, HidDeviceEnumeratorService>();
+            services.AddSingleton<IControllersEnumeratorService, ControllersEnumeratorService>();
+
+            services.AddSingleton<DeviceNotificationListener>();
+            services.AddSingleton<IDeviceNotificationListener>(provider =>
+                provider.GetRequiredService<DeviceNotificationListener>());
+            services.AddSingleton<IDeviceNotificationListenerSubscriber>(provider =>
+                provider.GetRequiredService<DeviceNotificationListener>());
+
+            services.AddHostedService<ControllerManagerHost>();
+        }
+
+        public void Initialize(IServiceProvider services)
+        {
+        }
+    }
+}

--- a/DS4Windows.Shared.Devices/Util/DeviceNotificationListener.cs
+++ b/DS4Windows.Shared.Devices/Util/DeviceNotificationListener.cs
@@ -1,0 +1,211 @@
+﻿using DS4Windows.Shared.Devices.HID;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Interop;
+
+namespace DS4Windows.Shared.Devices.Util
+{
+    /// <summary>
+    ///     Utility interface to add device arrival/removal notifications to WPF window.
+    /// </summary>
+    public interface IDeviceNotificationListener : IDeviceNotificationListenerSubscriber
+    {
+        void StartListen(Window window, Guid interfaceGuid);
+        void EndListen();
+    }
+
+    /// <summary>
+    ///     Utility class to add device arrival/removal notifications to WPF window.
+    /// </summary>
+    /// <remarks>Original source: https://gist.github.com/emoacht/73eff195317e387f4cda</remarks>
+    public class DeviceNotificationListener : IDeviceNotificationListener
+    {
+        private readonly ILogger<DeviceNotificationListener> logger;
+
+        public event Action<string> DeviceArrived;
+
+        public event Action<string> DeviceRemoved;
+
+        private IntPtr WndProc(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
+        {
+            if (msg == WM_DEVICECHANGE)
+            {
+                DEV_BROADCAST_HDR hdr;
+
+                switch ((int)wParam)
+                {
+                    case DBT_DEVICEARRIVAL:
+                        logger.LogDebug("Device added.");
+
+                        hdr = (DEV_BROADCAST_HDR)Marshal.PtrToStructure(lParam, typeof(DEV_BROADCAST_HDR));
+
+                        if (hdr.dbch_devicetype == DBT_DEVTYP_DEVICEINTERFACE)
+                        {
+                            var deviceInterface =
+                                (DEV_BROADCAST_DEVICEINTERFACE)Marshal.PtrToStructure(lParam,
+                                    typeof(DEV_BROADCAST_DEVICEINTERFACE));
+
+                            DeviceArrived?.Invoke(deviceInterface.dbcc_name);
+                        }
+
+                        break;
+
+                    case DBT_DEVICEREMOVECOMPLETE:
+                        logger.LogDebug("Device removed.");
+
+                        hdr = (DEV_BROADCAST_HDR)Marshal.PtrToStructure(lParam, typeof(DEV_BROADCAST_HDR));
+
+                        if (hdr.dbch_devicetype == DBT_DEVTYP_DEVICEINTERFACE)
+                        {
+                            var deviceInterface =
+                                (DEV_BROADCAST_DEVICEINTERFACE)Marshal.PtrToStructure(lParam,
+                                    typeof(DEV_BROADCAST_DEVICEINTERFACE));
+
+                            DeviceRemoved?.Invoke(deviceInterface.dbcc_name);
+                        }
+
+                        break;
+                }
+            }
+
+            return IntPtr.Zero;
+        }
+
+        #region Win32
+
+        [DllImport("User32.dll", SetLastError = true)]
+        private static extern IntPtr RegisterDeviceNotification(
+            IntPtr hRecipient,
+            IntPtr NotificationFilter,
+            uint Flags);
+
+        [DllImport("User32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool UnregisterDeviceNotification(IntPtr Handle);
+
+        private const uint DEVICE_NOTIFY_WINDOW_HANDLE = 0x00000000;
+
+        private const int WM_DEVICECHANGE = 0x0219;
+
+        private const int
+            DBT_DEVICEARRIVAL =
+                0x8000; // Device event when a device or piece of media has been inserted and becomes available
+
+        private const int
+            DBT_DEVICEREMOVECOMPLETE =
+                0x8004; // Device event when a device or piece of media has been physically removed
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct DEV_BROADCAST_HDR
+        {
+            public readonly uint dbch_size;
+            public readonly uint dbch_devicetype;
+            public readonly uint dbch_reserved;
+        }
+
+        private const uint DBT_DEVTYP_VOLUME = 0x00000002;
+        private const uint DBT_DEVTYP_DEVICEINTERFACE = 0x00000005;
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct DEV_BROADCAST_VOLUME
+        {
+            public readonly uint dbcv_size;
+            public readonly uint dbcv_devicetype;
+            public readonly uint dbcv_reserved;
+            public readonly uint dbcv_unitmask;
+            public readonly ushort dbcv_flags;
+        }
+
+        private const ushort DBTF_MEDIA = 0x0001; // Media in drive changed.
+        private const ushort DBTF_NET = 0x0002; // Network drive is changed.
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        private struct DEV_BROADCAST_DEVICEINTERFACE
+        {
+            public uint dbcc_size;
+            public uint dbcc_devicetype;
+            public readonly uint dbcc_reserved;
+            public Guid dbcc_classguid;
+
+            // To get value from lParam of WM_DEVICECHANGE, this length must be longer than 1.
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 255)]
+            public readonly string dbcc_name;
+        }
+
+        // Identifier: GUID_DEVINTERFACE_USB_DEVICE
+        // Class GUID: {A5DCBF10-6530-11D2-901F-00C04FB951ED}
+        private static readonly Guid GUID_DEVINTERFACE_USB_DEVICE = new("A5DCBF10-6530-11D2-901F-00C04FB951ED");
+
+        #endregion
+
+        #region Start/End
+
+        private HwndSource _handleSource;
+        private IntPtr _notificationHandle;
+
+        public DeviceNotificationListener(ILogger<DeviceNotificationListener> logger)
+        {
+            this.logger = logger;
+        }
+
+        public void StartListen(Window window, Guid interfaceGuid)
+        {
+            _handleSource = PresentationSource.FromVisual(window) as HwndSource;
+            if (_handleSource != null)
+            {
+                RegisterUsbDeviceNotification(_handleSource.Handle, interfaceGuid);
+                _handleSource.AddHook(WndProc);
+            }
+            else
+            {
+                logger.LogError("Failed to register device listener window message hook");
+            }
+        }
+
+        public void EndListen()
+        {
+            if (_handleSource != null)
+            {
+                UnregisterUsbDeviceNotification();
+                _handleSource.RemoveHook(WndProc);
+            }
+            else
+            {
+                logger.LogError("Failed to unregister device listener window message hook");
+            }
+        }
+
+        private void RegisterUsbDeviceNotification(IntPtr windowHandle, Guid interfaceGuid)
+        {
+            var dbcc = new DEV_BROADCAST_DEVICEINTERFACE
+            {
+                dbcc_size = (uint)Marshal.SizeOf(typeof(DEV_BROADCAST_DEVICEINTERFACE)),
+                dbcc_devicetype = DBT_DEVTYP_DEVICEINTERFACE,
+                dbcc_classguid = interfaceGuid
+            };
+
+            var notificationFilter = Marshal.AllocHGlobal(Marshal.SizeOf(dbcc));
+            Marshal.StructureToPtr(dbcc, notificationFilter, true);
+
+            _notificationHandle =
+                RegisterDeviceNotification(windowHandle, notificationFilter, DEVICE_NOTIFY_WINDOW_HANDLE);
+            if (_notificationHandle == IntPtr.Zero)
+                throw new Win32Exception(Marshal.GetLastWin32Error(), "Failed to register device notifications.");
+        }
+
+        private void UnregisterUsbDeviceNotification()
+        {
+            if (_notificationHandle != IntPtr.Zero)
+                UnregisterDeviceNotification(_notificationHandle);
+        }
+
+        #endregion
+    }
+}

--- a/DS4Windows.Shared.Emulator.ViGEmGen1/DS4Windows.Shared.Emulator.ViGEmGen1.csproj
+++ b/DS4Windows.Shared.Emulator.ViGEmGen1/DS4Windows.Shared.Emulator.ViGEmGen1.csproj
@@ -12,7 +12,6 @@
       <IncludeAssets>build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Nefarius.ViGEm.Client" Version="1.17.178" />
-    <PackageReference Include="OpenTelemetry" Version="1.1.0" />
       <PackageReference Include="PropertyChanged.Fody" Version="3.4.0" PrivateAssets="all" ExcludeAssets="runtime" />
     <PackageReference Include="ConfigureAwait.Fody" Version="3.3.1">
       <PrivateAssets>all</PrivateAssets>

--- a/DS4Windows/DS4WinWPF.csproj
+++ b/DS4Windows/DS4WinWPF.csproj
@@ -313,6 +313,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\DS4Windows.Client.Core\DS4Windows.Client.Core.csproj" />
     <ProjectReference Include="..\DS4Windows.Shared.Configuration.Application\DS4Windows.Shared.Configuration.Application.csproj" />
     <ProjectReference Include="..\DS4Windows.Shared.Common\DS4Windows.Shared.Common.csproj" />
     <ProjectReference Include="..\DS4Windows.Shared.Configuration.Profiles\DS4Windows.Shared.Configuration.Profiles.csproj" />


### PR DESCRIPTION
…ice... i think...

The device notification listener previously still only existed in the legacy app.  I was able to copy it over to devices project with no issues.  The different shared projects all now have their own registrars by only referencing client.core.  I think i properly started the controller hosted service which in turn properly starts the profile service and such.