### PR TITLE
Use metrics APIs for report parsing telemetry 

### DIFF
--- a/DS4Windows.Server.Host/appsettings.json
+++ b/DS4Windows.Server.Host/appsettings.json
@@ -21,6 +21,7 @@
     ]
   },
   "OpenTelemetry": {
-    "IsTracingEnabled": true
+    "IsTracingEnabled": true,
+    "IsMetricsEnabled": true
   }
 }

--- a/Ds4Windows.Shared.Devices.Interfaces/HID/ICompatibleHidDevice.cs
+++ b/Ds4Windows.Shared.Devices.Interfaces/HID/ICompatibleHidDevice.cs
@@ -8,8 +8,6 @@ namespace Ds4Windows.Shared.Devices.Interfaces.HID
         InputDeviceType DeviceType { get; set; }
         CompatibleHidDeviceFeatureSet FeatureSet { get; }
         bool IsInputReportAvailableInvoked { get; }
-        int ReportsPerSecondProcessed { get; }
-        int ReportsPerSecondRead { get; }
         PhysicalAddress Serial { get; }
 
         event Action<ICompatibleHidDevice> Disconnected;


### PR DESCRIPTION
This PR simplifies the telemetry logic in `CompatibleHidDevice` class by replacing tracing based telemetry with [metrics](https://learn.microsoft.com/en-us/dotnet/core/diagnostics/metrics-collection).

This allows us to very quickly check-out the current metrics with [``dotnet counters``](https://learn.microsoft.com/en-us/dotnet/core/diagnostics/dotnet-counters) for example:
```console
$ dotnet counters monitor -n DS4Windows.Server.Host DS4Windows.Shared.Devices
Press p to pause, r to resume, q to quit.
    Status: Running

[DS4Windows.Shared.Devices]
    reports-processed (Count / 1 sec)                252
    reports-read (Count / 1 sec)                     252
```