### PR TITLE
More HID refactoring

### DIFF
--- a/DS4Windows.Shared.Devices/HID/CompatibleHidDevice.Factory.cs
+++ b/DS4Windows.Shared.Devices/HID/CompatibleHidDevice.Factory.cs
@@ -16,26 +16,14 @@ public abstract partial class CompatibleHidDevice : ICompatibleHidDevice
     public static CompatibleHidDevice CreateFrom(InputDeviceType deviceType, HidDevice source,
         CompatibleHidDeviceFeatureSet featureSet, IServiceProvider services)
     {
-        CompatibleHidDevice device;
-        switch (deviceType)
+        return deviceType switch
         {
-            case InputDeviceType.DualShock4:
-                device = new DualShock4CompatibleHidDevice(deviceType, source, featureSet, services);
-                break;
-            case InputDeviceType.DualSense:
-                device = new DualSenseCompatibleHidDevice(deviceType, source, featureSet, services);
-                break;
-            case InputDeviceType.SwitchPro:
-                device = new SwitchProCompatibleHidDevice(deviceType, source, featureSet, services);
-                break;
-            case InputDeviceType.JoyConL:
-            case InputDeviceType.JoyConR:
-                device = new JoyConCompatibleHidDevice(deviceType, source, featureSet, services);
-                break;
-            default:
-                throw new ArgumentOutOfRangeException(nameof(deviceType), deviceType, null);
-        }
-
-        return device;
+            InputDeviceType.DualShock4 => new DualShock4CompatibleHidDevice(deviceType, source, featureSet, services),
+            InputDeviceType.DualSense => new DualSenseCompatibleHidDevice(deviceType, source, featureSet, services),
+            InputDeviceType.SwitchPro => new SwitchProCompatibleHidDevice(deviceType, source, featureSet, services),
+            InputDeviceType.JoyConL or InputDeviceType.JoyConR => new JoyConCompatibleHidDevice(deviceType, source, featureSet, services),
+            
+            _ => throw new ArgumentOutOfRangeException(nameof(deviceType), deviceType, null)
+        };
     }
 }

--- a/DS4Windows.Shared.Devices/HID/CompatibleHidDevice.cs
+++ b/DS4Windows.Shared.Devices/HID/CompatibleHidDevice.cs
@@ -18,17 +18,17 @@ namespace DS4Windows.Shared.Devices.HID;
 /// </summary>
 public abstract partial class CompatibleHidDevice : HidDevice, ICompatibleHidDevice
 {
+    private bool disposed;
+
     private static readonly Meter _meter = new Meter(TracingSources.DevicesAssemblyActivitySourceName);
 
     private static readonly Counter<int> _reportsReadCounter = _meter.CreateCounter<int>("reports-read", description: "The number of reports read.");
     private static readonly Counter<int> _reportsProcessedCounter = _meter.CreateCounter<int>("reports-processed", description: "The number of reports processed.");
 
     protected const string SonyWirelessAdapterFriendlyName = "DUALSHOCK®4 USB Wireless Adaptor";
+    
     protected static readonly Guid UsbDeviceClassGuid = Guid.Parse("{88BAE032-5A81-49f0-BC3D-A4FF138216D6}");
-
-    protected static readonly Guid UsbCompositeDeviceClassGuid =
-        Guid.Parse("{36fc9e60-c465-11cf-8056-444553540000}");
-
+    protected static readonly Guid UsbCompositeDeviceClassGuid = Guid.Parse("{36fc9e60-c465-11cf-8056-444553540000}");
     protected static readonly Guid BluetoothDeviceClassGuid = Guid.Parse("{e0cbf06c-cd8b-4647-bb8a-263b43f0f974}");
 
     protected readonly ActivitySource CoreActivity = new(TracingSources.DevicesAssemblyActivitySourceName);
@@ -109,10 +109,7 @@ public abstract partial class CompatibleHidDevice : HidDevice, ICompatibleHidDev
     /// <summary>
     ///     The <see cref="ConnectionType" /> of this <see cref="CompatibleHidDevice" />.
     /// </summary>
-    public ConnectionType? Connection
-    {
-        get { return connection ??= GetConnectionType(); }
-    }
+    public ConnectionType? Connection => connection ??= GetConnectionType();
 
     /// <summary>
     ///     The serial number (MAC address) of this <see cref="CompatibleHidDevice" />.
@@ -138,18 +135,6 @@ public abstract partial class CompatibleHidDevice : HidDevice, ICompatibleHidDev
     ///     Fired when a new input report is read for further processing.
     /// </summary>
     public event Action<ICompatibleHidDevice, CompatibleHidDeviceInputReport> InputReportAvailable;
-
-    public override void Dispose()
-    {
-        StopInputReportReader();
-
-        base.Dispose();
-    }
-
-    public override string ToString()
-    {
-        return $"{DisplayName} ({Serial}) via {Connection}";
-    }
 
     /// <summary>
     ///     Determine <see cref="ConnectionType" /> of this device.
@@ -397,4 +382,23 @@ public abstract partial class CompatibleHidDevice : HidDevice, ICompatibleHidDev
 
         return PhysicalAddress.Parse(address);
     }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (!disposed)
+        {
+            if (disposing)
+            {
+                CoreActivity.Dispose();
+
+                inputReportToken?.Dispose();
+            }
+
+            disposed = true;
+        }
+
+        base.Dispose(disposing);
+    }
+
+    public override string ToString() => $"{DisplayName} ({Serial}) via {Connection}";
 }

--- a/DS4Windows.Shared.Devices/HID/Devices/DualSenseCompatibleHidDevice.cs
+++ b/DS4Windows.Shared.Devices/HID/Devices/DualSenseCompatibleHidDevice.cs
@@ -4,13 +4,13 @@ using Microsoft.Extensions.Logging;
 
 namespace DS4Windows.Shared.Devices.HID.Devices;
 
-public class DualSenseCompatibleHidDevice : CompatibleHidDevice
+public sealed class DualSenseCompatibleHidDevice : CompatibleHidDevice
 {
     private const byte SerialFeatureId = 9;
     private const int UsbInputReportSize = 64;
     private const int BthInputReportSize = 547;
 
-    protected readonly int ReportStartOffset;
+    private readonly int reportStartOffset;
 
     public DualSenseCompatibleHidDevice(InputDeviceType deviceType, HidDevice source,
         CompatibleHidDeviceFeatureSet featureSet, IServiceProvider serviceProvider) : base(deviceType, source,
@@ -28,14 +28,14 @@ public class DualSenseCompatibleHidDevice : CompatibleHidDevice
         InputReportArray = new byte[inputReportSize];
 
         if (Connection is ConnectionType.Usb or ConnectionType.SonyWirelessAdapter)
-            ReportStartOffset = 0;
+            reportStartOffset = 0;
         //InputReportArray = new byte[UsbInputReportSize];
         //InputReportBuffer = Marshal.AllocHGlobal(InputReportArray.Length);
         //
         // TODO: finish me
         // 
         else
-            ReportStartOffset = 1;
+            reportStartOffset = 1;
         //InputReportArray = new byte[BthInputReportSize];
         //InputReportBuffer = Marshal.AllocHGlobal(InputReportArray.Length);
         StartInputReportReader();
@@ -45,6 +45,6 @@ public class DualSenseCompatibleHidDevice : CompatibleHidDevice
 
     protected override void ProcessInputReport(ReadOnlySpan<byte> input)
     {
-        InputReport.Parse(input.Slice(ReportStartOffset));
+        InputReport.Parse(input.Slice(reportStartOffset));
     }
 }

--- a/DS4Windows.Shared.Devices/HID/Devices/DualShock4CompatibleHidDevice.cs
+++ b/DS4Windows.Shared.Devices/HID/Devices/DualShock4CompatibleHidDevice.cs
@@ -4,13 +4,11 @@ using Microsoft.Extensions.Logging;
 
 namespace DS4Windows.Shared.Devices.HID.Devices;
 
-public class DualShock4CompatibleHidDevice : CompatibleHidDevice
+public sealed class DualShock4CompatibleHidDevice : CompatibleHidDevice
 {
     private const byte SerialFeatureId = 18;
 
-    protected readonly int ReportStartOffset;
-
-    private bool isConnected = false;
+    private readonly int reportStartOffset;
 
     public DualShock4CompatibleHidDevice(InputDeviceType deviceType, HidDevice source,
         CompatibleHidDeviceFeatureSet featureSet, IServiceProvider serviceProvider) : base(deviceType, source,
@@ -23,17 +21,15 @@ public class DualShock4CompatibleHidDevice : CompatibleHidDevice
 
         Logger.LogInformation("Got serial {Serial} for {Device}", Serial, this);
 
-        var inputReportSize = Capabilities.InputReportByteLength;
-
-        InputReportArray = new byte[inputReportSize];
+        InputReportArray = new byte[Capabilities.InputReportByteLength];
 
         if (Connection is ConnectionType.Usb or ConnectionType.SonyWirelessAdapter)
-            ReportStartOffset = 0;
+            reportStartOffset = 0;
         //
         // TODO: finish me
         // 
         else
-            ReportStartOffset = 1;
+            reportStartOffset = 1;
 
         StartInputReportReader();
     }
@@ -46,6 +42,6 @@ public class DualShock4CompatibleHidDevice : CompatibleHidDevice
             // TODO: implement me!
             return;
 
-        InputReport.Parse(input.Slice(ReportStartOffset));
+        InputReport.Parse(input.Slice(reportStartOffset));
     }
 }

--- a/DS4Windows.Shared.Devices/HID/Devices/JoyConCompatibleHidDevice.cs
+++ b/DS4Windows.Shared.Devices/HID/Devices/JoyConCompatibleHidDevice.cs
@@ -1,24 +1,22 @@
-﻿using System;
-using System.Net.NetworkInformation;
+﻿using System.Net.NetworkInformation;
 using DS4Windows.Shared.Devices.HID.Devices.Reports;
 using Ds4Windows.Shared.Devices.Interfaces.HID;
 
-namespace DS4Windows.Shared.Devices.HID.Devices
+namespace DS4Windows.Shared.Devices.HID.Devices;
+
+public sealed class JoyConCompatibleHidDevice : CompatibleHidDevice
 {
-    public class JoyConCompatibleHidDevice : CompatibleHidDevice
+    public JoyConCompatibleHidDevice(InputDeviceType deviceType, HidDevice source,
+        CompatibleHidDeviceFeatureSet featureSet, IServiceProvider serviceProvider) : base(deviceType, source,
+        featureSet, serviceProvider)
     {
-        public JoyConCompatibleHidDevice(InputDeviceType deviceType, HidDevice source,
-            CompatibleHidDeviceFeatureSet featureSet, IServiceProvider serviceProvider) : base(deviceType, source,
-            featureSet, serviceProvider)
-        {
-            Serial = PhysicalAddress.Parse(SerialNumberString);
-        }
-
-        protected override void ProcessInputReport(ReadOnlySpan<byte> input)
-        {
-            throw new NotImplementedException();
-        }
-
-        protected override CompatibleHidDeviceInputReport InputReport { get; } = new JoyConCompatibleInputReport();
+        Serial = PhysicalAddress.Parse(SerialNumberString);
     }
+
+    protected override void ProcessInputReport(ReadOnlySpan<byte> input)
+    {
+        throw new NotImplementedException();
+    }
+
+    protected override CompatibleHidDeviceInputReport InputReport { get; } = new JoyConCompatibleInputReport();
 }

--- a/DS4Windows.Shared.Devices/HID/Devices/Reports/DualSenseCompatibleInputReport.cs
+++ b/DS4Windows.Shared.Devices/HID/Devices/Reports/DualSenseCompatibleInputReport.cs
@@ -1,71 +1,70 @@
 ﻿using Ds4Windows.Shared.Devices.Interfaces.HID;
 
-namespace DS4Windows.Shared.Devices.HID.Devices.Reports
+namespace DS4Windows.Shared.Devices.HID.Devices.Reports;
+
+public sealed class DualSenseCompatibleInputReport : DualShock4CompatibleInputReport
 {
-    public class DualSenseCompatibleInputReport : DualShock4CompatibleInputReport
+    public override void Parse(ReadOnlySpan<byte> input)
     {
-        public override void Parse(ReadOnlySpan<byte> input)
+        // Eliminate bounds checks
+        input = input.Slice(0, 41);
+
+        ReportId = input[0];
+
+        LeftThumbX = input[1];
+        LeftThumbY = input[2];
+        RightThumbX = input[3];
+        RightThumbY = input[4];
+        LeftTrigger = input[5];
+        RightTrigger = input[6];
+
+        Triangle = (input[8] & (1 << 7)) != 0;
+        Circle = (input[8] & (1 << 6)) != 0;
+        Cross = (input[8] & (1 << 5)) != 0;
+        Square = (input[8] & (1 << 4)) != 0;
+
+        DPad = (DPadDirection)(input[8] & 0x0F);
+
+        LeftThumb = (input[9] & (1 << 6)) != 0;
+        RightThumb = (input[9] & (1 << 7)) != 0;
+        Options = (input[9] & (1 << 5)) != 0;
+        Share = (input[9] & (1 << 4)) != 0;
+        RightTriggerButton = (input[9] & (1 << 3)) != 0;
+        LeftTriggerButton = (input[9] & (1 << 2)) != 0;
+        RightShoulder = (input[9] & (1 << 1)) != 0;
+        LeftShoulder = (input[9] & (1 << 0)) != 0;
+
+        PS = (input[10] & (1 << 0)) != 0;
+
+        var touchX = ((input[35] & 0xF) << 8) | input[34];
+
+        TouchClick = (input[10] & (1 << 1)) != 0;
+        Mute = (input[10] & (1 << 2)) != 0;
+
+        TrackPadTouch1 = new TrackPadTouch
         {
-            // Eliminate bounds checks
-            input = input.Slice(0, 41);
-
-            ReportId = input[0];
-
-            LeftThumbX = input[1];
-            LeftThumbY = input[2];
-            RightThumbX = input[3];
-            RightThumbY = input[4];
-            LeftTrigger = input[5];
-            RightTrigger = input[6];
-
-            Triangle = (input[8] & (1 << 7)) != 0;
-            Circle = (input[8] & (1 << 6)) != 0;
-            Cross = (input[8] & (1 << 5)) != 0;
-            Square = (input[8] & (1 << 4)) != 0;
-
-            DPad = (DPadDirection)(input[8] & 0x0F);
-
-            LeftThumb = (input[9] & (1 << 6)) != 0;
-            RightThumb = (input[9] & (1 << 7)) != 0;
-            Options = (input[9] & (1 << 5)) != 0;
-            Share = (input[9] & (1 << 4)) != 0;
-            RightTriggerButton = (input[9] & (1 << 3)) != 0;
-            LeftTriggerButton = (input[9] & (1 << 2)) != 0;
-            RightShoulder = (input[9] & (1 << 1)) != 0;
-            LeftShoulder = (input[9] & (1 << 0)) != 0;
-
-            PS = (input[10] & (1 << 0)) != 0;
-
-            var touchX = ((input[35] & 0xF) << 8) | input[34];
-
-            TouchClick = (input[10] & (1 << 1)) != 0;
-            Mute = (input[10] & (1 << 2)) != 0;
-
-            TrackPadTouch1 = new TrackPadTouch
-            {
-                RawTrackingNum = input[33],
-                Id = (byte)(input[33] & 0x7f),
-                IsActive = (input[33] & 0x80) == 0,
-                X = (short)(((ushort)(input[35] & 0x0f) << 8) |
-                            input[34]),
-                Y = (short)((input[36] << 4) |
-                            ((ushort)(input[35] & 0xf0) >> 4))
-            };
-            TrackPadTouch2 = new TrackPadTouch
-            {
-                RawTrackingNum = input[37],
-                Id = (byte)(input[37] & 0x7f),
-                IsActive = (input[37] & 0x80) == 0,
-                X = (short)(((ushort)(input[39] & 0x0f) << 8) |
-                            input[38]),
-                Y = (short)((input[40] << 4) |
-                            ((ushort)(input[39] & 0xf0) >> 4))
-            };
-            TouchPacketCounter = input[41];
-            Touch1 = input[33] >> 7 == 0;
-            Touch2 = input[37] >> 7 == 0;
-            TouchIsOnLeftSide = !(touchX >= 1920 * 2 / 5); // TODO: port const
-            TouchIsOnRightSide = !(touchX < 1920 * 2 / 5); // TODO: port const
-        }
+            RawTrackingNum = input[33],
+            Id = (byte)(input[33] & 0x7f),
+            IsActive = (input[33] & 0x80) == 0,
+            X = (short)(((ushort)(input[35] & 0x0f) << 8) |
+                        input[34]),
+            Y = (short)((input[36] << 4) |
+                        ((ushort)(input[35] & 0xf0) >> 4))
+        };
+        TrackPadTouch2 = new TrackPadTouch
+        {
+            RawTrackingNum = input[37],
+            Id = (byte)(input[37] & 0x7f),
+            IsActive = (input[37] & 0x80) == 0,
+            X = (short)(((ushort)(input[39] & 0x0f) << 8) |
+                        input[38]),
+            Y = (short)((input[40] << 4) |
+                        ((ushort)(input[39] & 0xf0) >> 4))
+        };
+        TouchPacketCounter = input[41];
+        Touch1 = input[33] >> 7 == 0;
+        Touch2 = input[37] >> 7 == 0;
+        TouchIsOnLeftSide = !(touchX >= 1920 * 2 / 5); // TODO: port const
+        TouchIsOnRightSide = !(touchX < 1920 * 2 / 5); // TODO: port const
     }
 }

--- a/DS4Windows.Shared.Devices/HID/Devices/Reports/DualShock4CompatibleInputReport.cs
+++ b/DS4Windows.Shared.Devices/HID/Devices/Reports/DualShock4CompatibleInputReport.cs
@@ -1,121 +1,120 @@
 ﻿using Ds4Windows.Shared.Devices.Interfaces.HID;
 
-namespace DS4Windows.Shared.Devices.HID.Devices.Reports
+namespace DS4Windows.Shared.Devices.HID.Devices.Reports;
+
+public struct TrackPadTouch
 {
-    public struct TrackPadTouch
+    public bool IsActive;
+    public byte Id;
+    public short X;
+    public short Y;
+    public byte RawTrackingNum;
+}
+
+public class DualShock4CompatibleInputReport : CompatibleHidDeviceInputReport
+{
+    public TrackPadTouch TrackPadTouch1 { get; protected set; }
+
+    public TrackPadTouch TrackPadTouch2 { get; protected set; }
+
+    public byte TouchPacketCounter { get; protected set; }
+
+    public bool TouchOneFingerActive => Touch1 || Touch2;
+
+    public bool TouchTwoFingersActive => Touch1 && Touch2;
+
+    public bool Mute { get; protected set; }
+
+    /// <summary>
+    ///     First (one finger) touch is registered.
+    /// </summary>
+    public bool Touch1 { get; protected set; }
+
+    /// <summary>
+    ///     Second (two fingers) touch is registered.
+    /// </summary>
+    public bool Touch2 { get; protected set; }
+
+    public bool TouchIsOnLeftSide { get; protected set; }
+
+    public bool TouchIsOnRightSide { get; protected set; }
+
+    public bool TouchClick { get; protected set; }
+
+    /// <inheritdoc />
+    public override void Parse(ReadOnlySpan<byte> input)
     {
-        public bool IsActive;
-        public byte Id;
-        public short X;
-        public short Y;
-        public byte RawTrackingNum;
+        // Eliminate bounds checks
+        input = input.Slice(0, 43);
+
+        ReportId = input[0];
+
+        LeftThumbX = input[1];
+        LeftThumbY = input[2];
+        RightThumbX = input[3];
+        RightThumbY = input[4];
+        LeftTrigger = input[8];
+        RightTrigger = input[9];
+
+        Triangle = (input[5] & (1 << 7)) != 0;
+        Circle = (input[5] & (1 << 6)) != 0;
+        Cross = (input[5] & (1 << 5)) != 0;
+        Square = (input[5] & (1 << 4)) != 0;
+
+        DPad = (DPadDirection)(input[5] & 0x0F);
+
+        LeftThumb = (input[6] & (1 << 6)) != 0;
+        RightThumb = (input[6] & (1 << 7)) != 0;
+        Options = (input[6] & (1 << 5)) != 0;
+        Share = (input[6] & (1 << 4)) != 0;
+        RightTriggerButton = (input[6] & (1 << 3)) != 0;
+        LeftTriggerButton = (input[6] & (1 << 2)) != 0;
+        RightShoulder = (input[6] & (1 << 1)) != 0;
+        LeftShoulder = (input[6] & (1 << 0)) != 0;
+
+        PS = (input[7] & (1 << 0)) != 0;
+        TouchClick = (input[7] & (1 << 1)) != 0;
+
+        FrameCounter = (byte)(input[7] >> 2);
+
+        var touchX = ((input[35] & 0xF) << 8) | input[34];
+        
+        TrackPadTouch1 = new TrackPadTouch
+        {
+            RawTrackingNum = input[35],
+            Id = (byte)(input[35] & 0x7f),
+            IsActive = (input[35] & 0x80) == 0,
+            X = (short)(((ushort)(input[37] & 0x0f) << 8) |
+                        input[36]),
+            Y = (short)((input[39] << 4) |
+                        ((ushort)(input[37] & 0xf0) >> 4))
+        };
+        TrackPadTouch2 = new TrackPadTouch
+        {
+            RawTrackingNum = input[39],
+            Id = (byte)(input[39] & 0x7f),
+            IsActive = (input[39] & 0x80) == 0,
+            X = (short)(((ushort)(input[41] & 0x0f) << 8) |
+                        input[40]),
+            Y = (short)((input[42] << 4) |
+                        ((ushort)(input[41] & 0xf0) >> 4))
+        };
+        TouchPacketCounter = input[34];
+        Touch1 = input[35] >> 7 == 0;
+        Touch2 = input[39] >> 7 == 0;
+        TouchIsOnLeftSide = !(touchX >= 1920 * 2 / 5); // TODO: port const
+        TouchIsOnRightSide = !(touchX < 1920 * 2 / 5); // TODO: port const
     }
 
-    public class DualShock4CompatibleInputReport : CompatibleHidDeviceInputReport
+    /// <inheritdoc />
+    public override bool GetIsIdle()
     {
-        public TrackPadTouch TrackPadTouch1 { get; protected set; }
+        if (!base.GetIsIdle())
+            return false;
 
-        public TrackPadTouch TrackPadTouch2 { get; protected set; }
+        if (Touch1 || Touch2 || TouchClick)
+            return false;
 
-        public byte TouchPacketCounter { get; protected set; }
-
-        public bool TouchOneFingerActive => Touch1 || Touch2;
-
-        public bool TouchTwoFingersActive => Touch1 && Touch2;
-
-        public bool Mute { get; protected set; }
-
-        /// <summary>
-        ///     First (one finger) touch is registered.
-        /// </summary>
-        public bool Touch1 { get; protected set; }
-
-        /// <summary>
-        ///     Second (two fingers) touch is registered.
-        /// </summary>
-        public bool Touch2 { get; protected set; }
-
-        public bool TouchIsOnLeftSide { get; protected set; }
-
-        public bool TouchIsOnRightSide { get; protected set; }
-
-        public bool TouchClick { get; protected set; }
-
-        /// <inheritdoc />
-        public override void Parse(ReadOnlySpan<byte> input)
-        {
-            // Eliminate bounds checks
-            input = input.Slice(0, 43);
-
-            ReportId = input[0];
-
-            LeftThumbX = input[1];
-            LeftThumbY = input[2];
-            RightThumbX = input[3];
-            RightThumbY = input[4];
-            LeftTrigger = input[8];
-            RightTrigger = input[9];
-
-            Triangle = (input[5] & (1 << 7)) != 0;
-            Circle = (input[5] & (1 << 6)) != 0;
-            Cross = (input[5] & (1 << 5)) != 0;
-            Square = (input[5] & (1 << 4)) != 0;
-
-            DPad = (DPadDirection)(input[5] & 0x0F);
-
-            LeftThumb = (input[6] & (1 << 6)) != 0;
-            RightThumb = (input[6] & (1 << 7)) != 0;
-            Options = (input[6] & (1 << 5)) != 0;
-            Share = (input[6] & (1 << 4)) != 0;
-            RightTriggerButton = (input[6] & (1 << 3)) != 0;
-            LeftTriggerButton = (input[6] & (1 << 2)) != 0;
-            RightShoulder = (input[6] & (1 << 1)) != 0;
-            LeftShoulder = (input[6] & (1 << 0)) != 0;
-
-            PS = (input[7] & (1 << 0)) != 0;
-            TouchClick = (input[7] & (1 << 1)) != 0;
-
-            FrameCounter = (byte)(input[7] >> 2);
-
-            var touchX = ((input[35] & 0xF) << 8) | input[34];
-            
-            TrackPadTouch1 = new TrackPadTouch
-            {
-                RawTrackingNum = input[35],
-                Id = (byte)(input[35] & 0x7f),
-                IsActive = (input[35] & 0x80) == 0,
-                X = (short)(((ushort)(input[37] & 0x0f) << 8) |
-                            input[36]),
-                Y = (short)((input[39] << 4) |
-                            ((ushort)(input[37] & 0xf0) >> 4))
-            };
-            TrackPadTouch2 = new TrackPadTouch
-            {
-                RawTrackingNum = input[39],
-                Id = (byte)(input[39] & 0x7f),
-                IsActive = (input[39] & 0x80) == 0,
-                X = (short)(((ushort)(input[41] & 0x0f) << 8) |
-                            input[40]),
-                Y = (short)((input[42] << 4) |
-                            ((ushort)(input[41] & 0xf0) >> 4))
-            };
-            TouchPacketCounter = input[34];
-            Touch1 = input[35] >> 7 == 0;
-            Touch2 = input[39] >> 7 == 0;
-            TouchIsOnLeftSide = !(touchX >= 1920 * 2 / 5); // TODO: port const
-            TouchIsOnRightSide = !(touchX < 1920 * 2 / 5); // TODO: port const
-        }
-
-        /// <inheritdoc />
-        public override bool GetIsIdle()
-        {
-            if (!base.GetIsIdle())
-                return false;
-
-            if (Touch1 || Touch2 || TouchClick)
-                return false;
-
-            return true;
-        }
+        return true;
     }
 }

--- a/DS4Windows.Shared.Devices/HID/Devices/Reports/JoyConCompatibleInputReport.cs
+++ b/DS4Windows.Shared.Devices/HID/Devices/Reports/JoyConCompatibleInputReport.cs
@@ -1,115 +1,114 @@
 ﻿using Ds4Windows.Shared.Devices.Interfaces.HID;
 
-namespace DS4Windows.Shared.Devices.HID.Devices.Reports
+namespace DS4Windows.Shared.Devices.HID.Devices.Reports;
+
+/// <summary>
+///     TODO: unfinished!
+/// </summary>
+public sealed class JoyConCompatibleInputReport : CompatibleHidDeviceInputReport
 {
+    public TrackPadTouch TrackPadTouch1 { get; set; }
+
+    public TrackPadTouch TrackPadTouch2 { get; set; }
+
+    public byte TouchPacketCounter { get; set; }
+
+    public bool TouchOneFingerActive => Touch1 || Touch2;
+
+    public bool TouchTwoFingersActive => Touch1 && Touch2;
+
+    public bool Mute { get; set; }
+
     /// <summary>
-    ///     TODO: unfinished!
+    ///     First (one finger) touch is registered.
     /// </summary>
-    public class JoyConCompatibleInputReport : CompatibleHidDeviceInputReport
+    public bool Touch1 { get; set; }
+
+    /// <summary>
+    ///     Second (two fingers) touch is registered.
+    /// </summary>
+    public bool Touch2 { get; set; }
+
+    public bool TouchIsOnLeftSide { get; set; }
+
+    public bool TouchIsOnRightSide { get; set; }
+
+    public bool TouchClick { get; set; }
+
+    /// <inheritdoc />
+    public override void Parse(ReadOnlySpan<byte> input)
     {
-        public TrackPadTouch TrackPadTouch1;
+        // Eliminate bounds checks
+        input = input.Slice(0, 43);
 
-        public TrackPadTouch TrackPadTouch2;
+        ReportId = input[0];
 
-        public byte TouchPacketCounter { get; protected set; }
+        LeftThumbX = input[1];
+        LeftThumbY = input[2];
+        RightThumbX = input[3];
+        RightThumbY = input[4];
+        LeftTrigger = input[8];
+        RightTrigger = input[9];
 
-        public bool TouchOneFingerActive => Touch1 || Touch2;
+        Triangle = (input[5] & (1 << 7)) != 0;
+        Circle = (input[5] & (1 << 6)) != 0;
+        Cross = (input[5] & (1 << 5)) != 0;
+        Square = (input[5] & (1 << 4)) != 0;
 
-        public bool TouchTwoFingersActive => Touch1 && Touch2;
+        DPad = (DPadDirection)(input[5] & 0x0F);
 
-        public bool Mute { get; protected set; }
+        LeftThumb = (input[6] & (1 << 6)) != 0;
+        RightThumb = (input[6] & (1 << 7)) != 0;
+        Options = (input[6] & (1 << 5)) != 0;
+        Share = (input[6] & (1 << 4)) != 0;
+        RightTriggerButton = (input[6] & (1 << 3)) != 0;
+        LeftTriggerButton = (input[6] & (1 << 2)) != 0;
+        RightShoulder = (input[6] & (1 << 1)) != 0;
+        LeftShoulder = (input[6] & (1 << 0)) != 0;
 
-        /// <summary>
-        ///     First (one finger) touch is registered.
-        /// </summary>
-        public bool Touch1 { get; protected set; }
+        PS = (input[7] & (1 << 0)) != 0;
+        TouchClick = (input[7] & (1 << 1)) != 0;
 
-        /// <summary>
-        ///     Second (two fingers) touch is registered.
-        /// </summary>
-        public bool Touch2 { get; protected set; }
+        FrameCounter = (byte)(input[7] >> 2);
 
-        public bool TouchIsOnLeftSide { get; protected set; }
-
-        public bool TouchIsOnRightSide { get; protected set; }
-
-        public bool TouchClick { get; protected set; }
-
-        /// <inheritdoc />
-        public override void Parse(ReadOnlySpan<byte> input)
+        var touchX = ((input[35] & 0xF) << 8) | input[34];
+        
+        TrackPadTouch1 = new TrackPadTouch
         {
-            // Eliminate bounds checks
-            input = input.Slice(0, 43);
-
-            ReportId = input[0];
-
-            LeftThumbX = input[1];
-            LeftThumbY = input[2];
-            RightThumbX = input[3];
-            RightThumbY = input[4];
-            LeftTrigger = input[8];
-            RightTrigger = input[9];
-
-            Triangle = (input[5] & (1 << 7)) != 0;
-            Circle = (input[5] & (1 << 6)) != 0;
-            Cross = (input[5] & (1 << 5)) != 0;
-            Square = (input[5] & (1 << 4)) != 0;
-
-            DPad = (DPadDirection)(input[5] & 0x0F);
-
-            LeftThumb = (input[6] & (1 << 6)) != 0;
-            RightThumb = (input[6] & (1 << 7)) != 0;
-            Options = (input[6] & (1 << 5)) != 0;
-            Share = (input[6] & (1 << 4)) != 0;
-            RightTriggerButton = (input[6] & (1 << 3)) != 0;
-            LeftTriggerButton = (input[6] & (1 << 2)) != 0;
-            RightShoulder = (input[6] & (1 << 1)) != 0;
-            LeftShoulder = (input[6] & (1 << 0)) != 0;
-
-            PS = (input[7] & (1 << 0)) != 0;
-            TouchClick = (input[7] & (1 << 1)) != 0;
-
-            FrameCounter = (byte)(input[7] >> 2);
-
-            var touchX = ((input[35] & 0xF) << 8) | input[34];
-            
-            TrackPadTouch1 = new TrackPadTouch
-            {
-                RawTrackingNum = input[35],
-                Id = (byte)(input[35] & 0x7f),
-                IsActive = (input[35] & 0x80) == 0,
-                X = (short)(((ushort)(input[37] & 0x0f) << 8) |
-                            input[36]),
-                Y = (short)((input[39] << 4) |
-                            ((ushort)(input[37] & 0xf0) >> 4))
-            };
-            TrackPadTouch2 = new TrackPadTouch
-            {
-                RawTrackingNum = input[39],
-                Id = (byte)(input[39] & 0x7f),
-                IsActive = (input[39] & 0x80) == 0,
-                X = (short)(((ushort)(input[41] & 0x0f) << 8) |
-                            input[40]),
-                Y = (short)((input[42] << 4) |
-                            ((ushort)(input[41] & 0xf0) >> 4))
-            };
-            TouchPacketCounter = input[34];
-            Touch1 = input[35] >> 7 == 0;
-            Touch2 = input[39] >> 7 == 0;
-            TouchIsOnLeftSide = !(touchX >= 1920 * 2 / 5); // TODO: port const
-            TouchIsOnRightSide = !(touchX < 1920 * 2 / 5); // TODO: port const
-        }
-
-        /// <inheritdoc />
-        public override bool GetIsIdle()
+            RawTrackingNum = input[35],
+            Id = (byte)(input[35] & 0x7f),
+            IsActive = (input[35] & 0x80) == 0,
+            X = (short)(((ushort)(input[37] & 0x0f) << 8) |
+                        input[36]),
+            Y = (short)((input[39] << 4) |
+                        ((ushort)(input[37] & 0xf0) >> 4))
+        };
+        TrackPadTouch2 = new TrackPadTouch
         {
-            if (!base.GetIsIdle())
-                return false;
+            RawTrackingNum = input[39],
+            Id = (byte)(input[39] & 0x7f),
+            IsActive = (input[39] & 0x80) == 0,
+            X = (short)(((ushort)(input[41] & 0x0f) << 8) |
+                        input[40]),
+            Y = (short)((input[42] << 4) |
+                        ((ushort)(input[41] & 0xf0) >> 4))
+        };
+        TouchPacketCounter = input[34];
+        Touch1 = input[35] >> 7 == 0;
+        Touch2 = input[39] >> 7 == 0;
+        TouchIsOnLeftSide = !(touchX >= 1920 * 2 / 5); // TODO: port const
+        TouchIsOnRightSide = !(touchX < 1920 * 2 / 5); // TODO: port const
+    }
 
-            if (Touch1 || Touch2 || TouchClick)
-                return false;
+    /// <inheritdoc />
+    public override bool GetIsIdle()
+    {
+        if (!base.GetIsIdle())
+            return false;
 
-            return true;
-        }
+        if (Touch1 || Touch2 || TouchClick)
+            return false;
+
+        return true;
     }
 }

--- a/DS4Windows.Shared.Devices/HID/Devices/SwitchProCompatibleHidDevice.cs
+++ b/DS4Windows.Shared.Devices/HID/Devices/SwitchProCompatibleHidDevice.cs
@@ -1,21 +1,19 @@
-﻿using System;
-using Ds4Windows.Shared.Devices.Interfaces.HID;
+﻿using Ds4Windows.Shared.Devices.Interfaces.HID;
 
-namespace DS4Windows.Shared.Devices.HID.Devices
+namespace DS4Windows.Shared.Devices.HID.Devices;
+
+public sealed class SwitchProCompatibleHidDevice : CompatibleHidDevice
 {
-    public class SwitchProCompatibleHidDevice : CompatibleHidDevice
+    public SwitchProCompatibleHidDevice(InputDeviceType deviceType, HidDevice source,
+        CompatibleHidDeviceFeatureSet featureSet, IServiceProvider serviceProvider) : base(deviceType, source,
+        featureSet, serviceProvider)
     {
-        public SwitchProCompatibleHidDevice(InputDeviceType deviceType, HidDevice source,
-            CompatibleHidDeviceFeatureSet featureSet, IServiceProvider serviceProvider) : base(deviceType, source,
-            featureSet, serviceProvider)
-        {
-        }
-
-        protected override void ProcessInputReport(ReadOnlySpan<byte> input)
-        {
-            throw new NotImplementedException();
-        }
-
-        protected override CompatibleHidDeviceInputReport InputReport { get; }
     }
+
+    protected override void ProcessInputReport(ReadOnlySpan<byte> input)
+    {
+        throw new NotImplementedException();
+    }
+
+    protected override CompatibleHidDeviceInputReport InputReport { get; }
 }

--- a/Ds4Windows.Shared.Devices.Interfaces/HID/IHidDevice.cs
+++ b/Ds4Windows.Shared.Devices.Interfaces/HID/IHidDevice.cs
@@ -1,27 +1,22 @@
 ﻿using Windows.Win32.Devices.HumanInterfaceDevice;
 
-namespace Ds4Windows.Shared.Devices.Interfaces.HID
-{
-    public interface IHidDevice
-    {
-        HIDD_ATTRIBUTES Attributes { get; set; }
-        HIDP_CAPS Capabilities { get; set; }
-        string Description { get; set; }
-        string DisplayName { get; set; }
-        string InstanceId { get; set; }
-        bool IsOpen { get; }
-        bool IsVirtual { get; set; }
-        string ManufacturerString { get; set; }
-        string ParentInstance { get; set; }
-        string Path { get; set; }
-        string ProductString { get; set; }
-        string SerialNumberString { get; set; }
+namespace Ds4Windows.Shared.Devices.Interfaces.HID;
 
-        void CloseDevice();
-        void Dispose();
-        bool Equals(object obj);
-        int GetHashCode();
-        void OpenDevice();
-        string ToString();
-    }
+public interface IHidDevice : IDisposable
+{
+    HIDD_ATTRIBUTES Attributes { get; set; }
+    HIDP_CAPS Capabilities { get; set; }
+    string Description { get; set; }
+    string DisplayName { get; set; }
+    string InstanceId { get; set; }
+    bool IsOpen { get; }
+    bool IsVirtual { get; set; }
+    string ManufacturerString { get; set; }
+    string ParentInstance { get; set; }
+    string Path { get; set; }
+    string ProductString { get; set; }
+    string SerialNumberString { get; set; }
+
+    void CloseDevice();
+    void OpenDevice();
 }


### PR DESCRIPTION
* Fixed/refactored equality implementation of the ``HidDevice``
* Fixed the [``IDisposable`` pattern](https://learn.microsoft.com/en-us/dotnet/standard/garbage-collection/implementing-dispose) of the ``HidDevice``.
  * Same for ``CompatibleHidDevice``
* Spanified the ``HidDevice`` interop.
  * Made ``ReadInputReport.ReadInputReport(Span<byte> buffer)`` return ``int`` to follow common .NET pattern for IO ``Read`` APIs (see ``int Stream.Read(buf)`` etc.) instead of ``out int bytesRead``
* Simplified ``CompatibleHidDevice.ReadSerial`` logic a bit.
* Seal couple Hid interop related classes, file-scoped namespaces & switch expression.