### PR TITLE
Implemented auto filter

### DIFF
--- a/Vapour.Client.Modules/Controllers/ControllersListView.xaml
+++ b/Vapour.Client.Modules/Controllers/ControllersListView.xaml
@@ -44,28 +44,6 @@
                             </DataTemplate>
                         </GridViewColumn.CellTemplate>
                     </GridViewColumn>
-                    <GridViewColumn>
-                        <GridViewColumn.CellTemplate>
-                            <DataTemplate>
-                                <Button Command="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=UserControl}, Path=DataContext.FilterCommand}"
-                                        CommandParameter="{Binding}"
-                                          Content="Filter"
-                                        Visibility="{Binding IsFiltered, Converter={StaticResource falseIsVis}}">
-                                </Button>
-                            </DataTemplate>
-                        </GridViewColumn.CellTemplate>
-                    </GridViewColumn>
-                    <GridViewColumn>
-                        <GridViewColumn.CellTemplate>
-                            <DataTemplate>
-                                <Button Command="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=UserControl}, Path=DataContext.UnfilterCommand}"
-                                        CommandParameter="{Binding}"
-                                          Content="Unfilter"
-                                        Visibility="{Binding IsFiltered, Converter={StaticResource trueIsVis}}">
-                                </Button>
-                            </DataTemplate>
-                        </GridViewColumn.CellTemplate>
-                    </GridViewColumn>
                 </GridView>
             </ListView.View>
         </ListView>

--- a/Vapour.Client.Modules/Controllers/ControllersViewModel.cs
+++ b/Vapour.Client.Modules/Controllers/ControllersViewModel.cs
@@ -2,7 +2,6 @@
 using System.Collections.Specialized;
 
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Toolkit.Mvvm.Input;
 
 using Vapour.Client.Core.ViewModel;
 using Vapour.Client.Modules.Profiles;
@@ -28,14 +27,9 @@ public class ControllersViewModel : NavigationTabViewModel<IControllersViewModel
         this.controllerService = controllerService;
         this.profilesService = profilesService;
 
-        FilterCommand = new RelayCommand<IControllerItemViewModel>(FilterController);
-        UnfilterCommand = new RelayCommand<IControllerItemViewModel>(UnfilterController);
-
         CreateSelectableProfileItems();
     }
-
-    public RelayCommand<IControllerItemViewModel> FilterCommand { get; }
-    public RelayCommand<IControllerItemViewModel> UnfilterCommand { get; }
+    
     public ObservableCollection<IControllerItemViewModel> ControllerItems { get; } = new();
     public ObservableCollection<ISelectableProfileItemViewModel> SelectableProfileItems { get; } = new();
 
@@ -108,16 +102,6 @@ public class ControllersViewModel : NavigationTabViewModel<IControllersViewModel
             existing.Dispose();
             SelectableProfileItems.Remove(existing);
         }
-    }
-
-    public void FilterController(IControllerItemViewModel controller)
-    {
-        controllerService.FilterController(controller.InstanceId);
-    }
-
-    public void UnfilterController(IControllerItemViewModel controller)
-    {
-        controllerService.UnfilterController(controller.InstanceId);
     }
 
     protected override void Dispose(bool disposing)

--- a/Vapour.Shared.Configuration.Application/Schema/ApplicationSettingsSchema.cs
+++ b/Vapour.Shared.Configuration.Application/Schema/ApplicationSettingsSchema.cs
@@ -122,4 +122,6 @@ public class DS4WindowsAppSettings : JsonSerializable<DS4WindowsAppSettings>
     public Dictionary<int, Guid?> Profiles { get; set; } = new(Enumerable
         .Range(0, Constants.MaxControllers)
         .Select(i => new KeyValuePair<int, Guid?>(i, null)));
+
+    public bool? IsFilteringEnabled { get; set; }
 }

--- a/Vapour.Shared.Devices.Interfaces/HID/KnownDevices.cs
+++ b/Vapour.Shared.Devices.Interfaces/HID/KnownDevices.cs
@@ -13,6 +13,15 @@ public static class KnownDevices
     private const int JoyconLProductId = 0x2006;
     private const int JoyconRProductId = 0x2007;
 
+    public static VidPidInfo IsWinUsbRewriteSupported(int vid, int pid)
+    {
+        var supportedDevice = KnownDevices.List.SingleOrDefault(i =>
+            i.WinUsbEndpoints != null && i.Vid == vid &&
+            i.Pid == pid);
+
+        return supportedDevice;
+    }
+
     public static readonly IEnumerable<VidPidInfo> List = new List<VidPidInfo>
     {
         new(SonyVid, 0xBA0, "Sony WA",

--- a/Vapour.Shared.Devices/Services/WinUsbDeviceEnumeratorService.cs
+++ b/Vapour.Shared.Devices/Services/WinUsbDeviceEnumeratorService.cs
@@ -112,9 +112,8 @@ public class WinUsbDeviceEnumeratorService : IHidDeviceEnumeratorService<HidDevi
         {
             using USBDevice winUsbDevice = USBDevice.GetSingleDeviceByPath(path);
 
-            var supportedDevice = KnownDevices.List.SingleOrDefault(i =>
-                i.WinUsbEndpoints != null && i.Vid == winUsbDevice.Descriptor.VID &&
-                i.Pid == winUsbDevice.Descriptor.PID);
+            var supportedDevice =
+                KnownDevices.IsWinUsbRewriteSupported(winUsbDevice.Descriptor.VID, winUsbDevice.Descriptor.PID);
             
             // Filter out devices we don't know about
             if (supportedDevice == null)

--- a/Vapour.Shared.Devices/Vapour.Shared.Devices.csproj
+++ b/Vapour.Shared.Devices/Vapour.Shared.Devices.csproj
@@ -37,6 +37,7 @@
 		<ProjectReference Include="..\Vapour.Client.Core.Interfaces\Vapour.Client.Core.Interfaces.csproj" />
 		<ProjectReference Include="..\Vapour.Shared.Common.Interfaces\Vapour.Shared.Common.Interfaces.csproj" />
 		<ProjectReference Include="..\Vapour.Shared.Common.Utils\Vapour.Shared.Common.Util.csproj" />
+		<ProjectReference Include="..\Vapour.Shared.Configuration.Application\Vapour.Shared.Configuration.Application.csproj" />
 		<ProjectReference Include="..\Vapour.Shared.Configuration.Profiles.Interfaces\Vapour.Shared.Configuration.Profiles.Interfaces.csproj" />
 		<ProjectReference Include="..\Vapour.Shared.Devices.Interfaces\Vapour.Shared.Devices.Interfaces.csproj" />
 	</ItemGroup>


### PR DESCRIPTION
Auto filter will default to true if the config entry does not exist (which includes initial run of the service)
when hid enumerator catches a filter supported controller while global filter is enabled it will filter the controller and cycle its usb port
turning global filter off will call unfilter on all currently active controllers, recycle their ports and save the new state of the config
turning global filter on will filter all currently active supported controllers and then regardless will cycle each port and save the new state of the config