### PR TITLE
Use CommunityToolkit's ObservableProperty source-generation where possible

### DIFF
--- a/Vapour.Client.Modules/InputSource/AddGameListViewModel.cs
+++ b/Vapour.Client.Modules/InputSource/AddGameListViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.ObjectModel;
 
+using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 
 using Vapour.Client.Core.ViewModel;
@@ -8,12 +9,13 @@ using Vapour.Shared.Devices.Services.Configuration;
 
 namespace Vapour.Client.Modules.InputSource;
 
-public sealed class AddGameListViewModel : ViewModel<IAddGameListViewModel>, IAddGameListViewModel
+public sealed partial class AddGameListViewModel : ViewModel<IAddGameListViewModel>, IAddGameListViewModel
 {
     private readonly IInputSourceServiceClient _inputSourceServiceClient;
     private string _inputSourceKey;
     private Func<Task> _onCompletedAction;
 
+    [ObservableProperty]
     private GameInfo _selectedGame;
 
     public AddGameListViewModel(IInputSourceServiceClient inputSourceServiceClient)
@@ -27,12 +29,6 @@ public sealed class AddGameListViewModel : ViewModel<IAddGameListViewModel>, IAd
     public ObservableCollection<GameInfo> Games { get; private set; }
     public RelayCommand AddGameCommand { get; }
     public RelayCommand CancelCommand { get; }
-
-    public GameInfo SelectedGame
-    {
-        get => _selectedGame;
-        set => SetProperty(ref _selectedGame, value);
-    }
 
     public async Task Initialize(string inputSourceKey, GameSource gameSource, Func<Task> onCompleted)
     {

--- a/Vapour.Client.Modules/InputSource/InputSourceConfigureViewModel.cs
+++ b/Vapour.Client.Modules/InputSource/InputSourceConfigureViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.ObjectModel;
 using System.IO;
 
+using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 
 using Microsoft.Win32;
@@ -12,14 +13,17 @@ using Vapour.Shared.Devices.Services.Configuration;
 
 namespace Vapour.Client.Modules.InputSource;
 
-public sealed class InputSourceConfigureViewModel : ViewModel<InputSourceConfigureViewModel>,
+public sealed partial class InputSourceConfigureViewModel : ViewModel<InputSourceConfigureViewModel>,
     IInputSourceConfigureViewModel
 {
     private readonly IInputSourceServiceClient _inputSourceServiceClient;
     private readonly IViewModelFactory _viewModelFactory;
 
+    [ObservableProperty]
     private ObservableCollection<IGameConfigurationItemViewModel> _gameConfigurations;
 
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsGameListPresent))]
     private IView _gameListView;
 
     public InputSourceConfigureViewModel(IViewModelFactory viewModelFactory,
@@ -34,25 +38,9 @@ public sealed class InputSourceConfigureViewModel : ViewModel<InputSourceConfigu
     public RelayCommand<GameSource> AddGameCommand { get; }
     public RelayCommand<IGameConfigurationItemViewModel> DeleteGameConfigurationCommand { get; }
 
-    public ObservableCollection<IGameConfigurationItemViewModel> GameConfigurations
-    {
-        get => _gameConfigurations;
-        private set => SetProperty(ref _gameConfigurations, value);
-    }
-
     public bool IsGameListPresent => GameListView != null;
 
     public IInputSourceItemViewModel InputSourceItem { get; private set; }
-
-    public IView GameListView
-    {
-        get => _gameListView;
-        private set
-        {
-            SetProperty(ref _gameListView, value);
-            OnPropertyChanged(nameof(IsGameListPresent));
-        }
-    }
 
     public async Task SetInputSourceToConfigure(IInputSourceItemViewModel inputSourceItemViewModel)
     {

--- a/Vapour.Client.Modules/InputSource/InputSourceControllerItemViewModel.cs
+++ b/Vapour.Client.Modules/InputSource/InputSourceControllerItemViewModel.cs
@@ -1,23 +1,34 @@
 ﻿using System.Windows.Media.Imaging;
 
+using CommunityToolkit.Mvvm.ComponentModel;
+
 using Vapour.Client.Core.ViewModel;
 
 namespace Vapour.Client.Modules.InputSource;
-public class InputSourceControllerItemViewModel : ViewModel<IInputSourceControllerItemViewModel>, IInputSourceControllerItemViewModel
+
+public partial class InputSourceControllerItemViewModel : ViewModel<IInputSourceControllerItemViewModel>, IInputSourceControllerItemViewModel
 {
+    [ObservableProperty]
     private decimal _batteryPercentage;
 
+    [ObservableProperty]
     private BitmapImage _connectionTypeImage;
 
+    [ObservableProperty]
     private BitmapImage _deviceImage;
 
+    [ObservableProperty]
     private string _displayText;
 
+    [ObservableProperty]
     private bool _isFiltered;
 
+    [ObservableProperty]
     private string _serial;
 
+    [ObservableProperty]
     private string _deviceKey;
+    
     private const string ImageLocationRoot =
         "pack://application:,,,/Vapour.Client.Modules;component/InputSource/Images";
 
@@ -45,48 +56,6 @@ public class InputSourceControllerItemViewModel : ViewModel<IInputSourceControll
                 return null;
             }
         }
-    }
-
-    public string Serial
-    {
-        get => _serial;
-        private set => SetProperty(ref _serial, value);
-    }
-
-    public BitmapImage DeviceImage
-    {
-        get => _deviceImage;
-        private set => SetProperty(ref _deviceImage, value);
-    }
-
-    public string DisplayText
-    {
-        get => _displayText;
-        private set => SetProperty(ref _displayText, value);
-    }
-
-    public BitmapImage ConnectionTypeImage
-    {
-        get => _connectionTypeImage;
-        private set => SetProperty(ref _connectionTypeImage, value);
-    }
-
-    public decimal BatteryPercentage
-    {
-        get => _batteryPercentage;
-        private set => SetProperty(ref _batteryPercentage, value);
-    }
-
-    public bool IsFiltered
-    {
-        get => _isFiltered;
-        set => SetProperty(ref _isFiltered, value);
-    }
-
-    public string DeviceKey
-    {
-        get => _deviceKey;
-        set => SetProperty(ref _deviceKey, value);
     }
 
     public string InstanceId { get; set; }

--- a/Vapour.Client.Modules/InputSource/InputSourceItemViewModel.Properties.cs
+++ b/Vapour.Client.Modules/InputSource/InputSourceItemViewModel.Properties.cs
@@ -18,7 +18,6 @@ public sealed partial class InputSourceItemViewModel
     private SolidColorBrush _currentColor;
 
     [ObservableProperty]
-
     [NotifyPropertyChangedFor(nameof(SelectedProfileId))]
     [NotifyPropertyChangedFor(nameof(IsPassthru))]
     [NotifyPropertyChangedFor(nameof(OutputDeviceType))]

--- a/Vapour.Client.Modules/InputSource/InputSourceItemViewModel.Properties.cs
+++ b/Vapour.Client.Modules/InputSource/InputSourceItemViewModel.Properties.cs
@@ -1,6 +1,8 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.Windows.Media;
 
+using CommunityToolkit.Mvvm.ComponentModel;
+
 using Vapour.Shared.Common.Types;
 using Vapour.Shared.Devices.Services.Configuration;
 
@@ -9,12 +11,24 @@ namespace Vapour.Client.Modules.InputSource;
 [SuppressMessage("ReSharper", "UnusedMember.Local")]
 public sealed partial class InputSourceItemViewModel
 {
+    [ObservableProperty]
     private List<IInputSourceControllerItemViewModel> _controllers = new();
 
+    [ObservableProperty]
     private SolidColorBrush _currentColor;
 
+    [ObservableProperty]
+
+    [NotifyPropertyChangedFor(nameof(SelectedProfileId))]
+    [NotifyPropertyChangedFor(nameof(IsPassthru))]
+    [NotifyPropertyChangedFor(nameof(OutputDeviceType))]
+    [NotifyPropertyChangedFor(nameof(IsProfileSetEnabled))]
+    [NotifyPropertyChangedFor(nameof(IsGameConfiguration))]
+    [NotifyPropertyChangedFor(nameof(GameInfo))]
+    [NotifyPropertyChangedFor(nameof(GameSource))]
     private InputSourceConfiguration _currentConfiguration;
 
+    [ObservableProperty]
     private string _inputSourceKey;
 
     public bool IsProfileSetEnabled => !IsPassthru && OutputDeviceType != OutputDeviceType.None;
@@ -61,12 +75,6 @@ public sealed partial class InputSourceItemViewModel
 
     public bool ConfigurationSetFromUser { get; set; } = true;
 
-    public string InputSourceKey
-    {
-        get => _inputSourceKey;
-        set => SetProperty(ref _inputSourceKey, value);
-    }
-    
     public Guid SelectedProfileId
     {
         get => CurrentConfiguration.ProfileId;
@@ -78,33 +86,5 @@ public sealed partial class InputSourceItemViewModel
                 OnPropertyChanged();
             }
         }
-    }
-
-    public SolidColorBrush CurrentColor
-    {
-        get => _currentColor;
-        set => SetProperty(ref _currentColor, value);
-    }
-
-    public InputSourceConfiguration CurrentConfiguration
-    {
-        get => _currentConfiguration;
-        set
-        {
-            SetProperty(ref _currentConfiguration, value);
-            OnPropertyChanged(nameof(SelectedProfileId));
-            OnPropertyChanged(nameof(IsPassthru));
-            OnPropertyChanged(nameof(OutputDeviceType));
-            OnPropertyChanged(nameof(IsProfileSetEnabled));
-            OnPropertyChanged(nameof(IsGameConfiguration));
-            OnPropertyChanged(nameof(GameInfo));
-            OnPropertyChanged(nameof(GameSource));
-        }
-    }
-
-    public List<IInputSourceControllerItemViewModel> Controllers
-    {
-        get => _controllers;
-        set => SetProperty(ref _controllers, value);
     }
 }

--- a/Vapour.Client.Modules/Main/MainWindowViewModel.cs
+++ b/Vapour.Client.Modules/Main/MainWindowViewModel.cs
@@ -1,10 +1,12 @@
 ﻿using System.Collections.ObjectModel;
 
+using CommunityToolkit.Mvvm.ComponentModel;
+
 using Vapour.Client.Core.ViewModel;
 
 namespace Vapour.Client.Modules.Main;
 
-public sealed class MainWindowViewModel : 
+public sealed partial class MainWindowViewModel : 
     ViewModel<IMainViewModel>, 
     IMainViewModel
 {
@@ -27,13 +29,8 @@ public sealed class MainWindowViewModel :
 
     public ObservableCollection<IViewModel> NavigationItems { get; private set; }
 
+    [ObservableProperty]
     private IViewModel _selectedPage;
-
-    public IViewModel SelectedPage
-    {
-        get => _selectedPage;
-        set => SetProperty(ref _selectedPage, value);
-    }
 
     #endregion
 }

--- a/Vapour.Client.Modules/Profiles/Edit/ProfileEditViewModel.cs
+++ b/Vapour.Client.Modules/Profiles/Edit/ProfileEditViewModel.cs
@@ -2,6 +2,8 @@
 
 using AutoMapper;
 
+using CommunityToolkit.Mvvm.ComponentModel;
+
 using FastDeepCloner;
 
 using Vapour.Client.Core.ViewModel;
@@ -10,27 +12,36 @@ using Vapour.Shared.Configuration.Profiles.Schema;
 
 namespace Vapour.Client.Modules.Profiles.Edit;
 
-public sealed class ProfileEditViewModel : ViewModel<IProfileEditViewModel>, IProfileEditViewModel, IDataErrorInfo
+public sealed partial class ProfileEditViewModel : ViewModel<IProfileEditViewModel>, IProfileEditViewModel, IDataErrorInfo
 {
     private readonly IMapper _mapper;
     private readonly IProfileServiceClient _profileServiceClient;
     private readonly IViewModelFactory _viewModelFactory;
 
-    private bool _isNew;
-
-    private ITriggerButtonsEditViewModel _l2Button;
-
-    private IStickEditViewModel _leftStick;
-
-    private string _name;
     private IProfile _profile;
 
+    [ObservableProperty]
+    private bool _isNew;
+
+    [ObservableProperty]
+    private ITriggerButtonsEditViewModel _l2Button;
+
+    [ObservableProperty]
+    private IStickEditViewModel _leftStick;
+
+    [ObservableProperty]
+    private string _name;
+
+    [ObservableProperty]
     private ITriggerButtonsEditViewModel _r2Button;
 
+    [ObservableProperty]
     private IStickEditViewModel _rightStick;
 
+    [ObservableProperty]
     private ISixAxisEditViewModel _sixAxisX;
 
+    [ObservableProperty]
     private ISixAxisEditViewModel _sixAxisZ;
 
     public ProfileEditViewModel(
@@ -43,30 +54,6 @@ public sealed class ProfileEditViewModel : ViewModel<IProfileEditViewModel>, IPr
         _profileServiceClient = profileServiceClient;
     }
 
-    public ITriggerButtonsEditViewModel L2Button
-    {
-        get => _l2Button;
-        private set => SetProperty(ref _l2Button, value);
-    }
-
-    public ITriggerButtonsEditViewModel R2Button
-    {
-        get => _r2Button;
-        private set => SetProperty(ref _r2Button, value);
-    }
-
-    public ISixAxisEditViewModel SixAxisX
-    {
-        get => _sixAxisX;
-        private set => SetProperty(ref _sixAxisX, value);
-    }
-
-    public ISixAxisEditViewModel SixAxisZ
-    {
-        get => _sixAxisZ;
-        private set => SetProperty(ref _sixAxisZ, value);
-    }
-
     public override async Task Initialize()
     {
         _leftStick = await _viewModelFactory.Create<IStickEditViewModel, IStickEditView>();
@@ -75,30 +62,6 @@ public sealed class ProfileEditViewModel : ViewModel<IProfileEditViewModel>, IPr
         _r2Button = await _viewModelFactory.Create<ITriggerButtonsEditViewModel, ITriggerButtonsEditView>();
         _sixAxisX = await _viewModelFactory.Create<ISixAxisEditViewModel, ISixAxisEditView>();
         _sixAxisZ = await _viewModelFactory.Create<ISixAxisEditViewModel, ISixAxisEditView>();
-    }
-
-    public bool IsNew
-    {
-        get => _isNew;
-        private set => SetProperty(ref _isNew, value);
-    }
-
-    public string Name
-    {
-        get => _name;
-        set => SetProperty(ref _name, value);
-    }
-
-    public IStickEditViewModel LeftStick
-    {
-        get => _leftStick;
-        private set => SetProperty(ref _leftStick, value);
-    }
-
-    public IStickEditViewModel RightStick
-    {
-        get => _rightStick;
-        private set => SetProperty(ref _rightStick, value);
     }
 
     public string Error { get; private set; }

--- a/Vapour.Client.Modules/Profiles/Edit/SixAxisEditViewModel.cs
+++ b/Vapour.Client.Modules/Profiles/Edit/SixAxisEditViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics;
 
+using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 
 using Vapour.Client.Core;
@@ -9,7 +10,7 @@ using Vapour.Shared.Common.Types;
 
 namespace Vapour.Client.Modules.Profiles.Edit;
 
-public sealed class SixAxisEditViewModel :
+public sealed partial class SixAxisEditViewModel :
     ViewModel<ISixAxisEditViewModel>,
     ISixAxisEditViewModel
 {
@@ -17,12 +18,14 @@ public sealed class SixAxisEditViewModel :
 
     private double _antiDeadZone;
 
+    [ObservableProperty]
     private BezierCurve _customCurve;
 
     private double _deadZone;
 
     private double _maxZone;
 
+    [ObservableProperty]
     private CurveMode _outputCurve;
 
     private double _sensitivity;
@@ -61,18 +64,6 @@ public sealed class SixAxisEditViewModel :
         set => SetProperty(ref _sensitivity, Math.Round(value, 1));
         //Math round needed because wpf slider control when binding to double and tick increment
         //of 0.1 when it hits values like 1.2 and 2.2 it sends 1.20000000002 or something like that
-    }
-
-    public CurveMode OutputCurve
-    {
-        get => _outputCurve;
-        set => SetProperty(ref _outputCurve, value);
-    }
-
-    public BezierCurve CustomCurve
-    {
-        get => _customCurve;
-        set => SetProperty(ref _customCurve, value);
     }
 
     private void OnShowCustomCurve()

--- a/Vapour.Client.Modules/Profiles/Edit/StickControlModeSettingsViewModel.cs
+++ b/Vapour.Client.Modules/Profiles/Edit/StickControlModeSettingsViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using System.ComponentModel;
 using System.Diagnostics;
 
+using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 
 using Vapour.Client.Core;
@@ -10,26 +11,35 @@ using Vapour.Shared.Common.Types;
 
 namespace Vapour.Client.Modules.Profiles.Edit;
 
-public sealed class StickControlModeSettingsViewModel :
+public sealed partial class StickControlModeSettingsViewModel :
     ViewModel<IStickControlModeSettingsViewModel>,
     IStickControlModeSettingsViewModel
 {
     private readonly IDeviceValueConverters _deviceValueConverters;
 
+    [ObservableProperty]
     private int _antiSnapbackDelta;
 
+    [ObservableProperty]
     private int _antiSnapbackTimeout;
 
+    [ObservableProperty]
     private BezierCurve _customCurve;
 
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsRadialSet))]
     private StickDeadZoneInfo.DeadZoneType _deadZoneType;
 
+    [ObservableProperty]
     private int _fuzz;
 
+    [ObservableProperty]
     private bool _isAntiSnapback;
 
+    [ObservableProperty]
     private bool _isSquareStick;
 
+    [ObservableProperty]
     private CurveMode _outputCurve;
 
     private double _squareStickRoundness;
@@ -52,30 +62,6 @@ public sealed class StickControlModeSettingsViewModel :
         set => Rotation = _deviceValueConverters.RotationConvertTo(value);
     }
 
-    public StickDeadZoneInfo.DeadZoneType DeadZoneType
-    {
-        get => _deadZoneType;
-        set => SetProperty(ref _deadZoneType, value);
-    }
-
-    public CurveMode OutputCurve
-    {
-        get => _outputCurve;
-        set => SetProperty(ref _outputCurve, value);
-    }
-
-    public BezierCurve CustomCurve
-    {
-        get => _customCurve;
-        set => SetProperty(ref _customCurve, value);
-    }
-
-    public bool IsSquareStick
-    {
-        get => _isSquareStick;
-        set => SetProperty(ref _isSquareStick, value);
-    }
-
     public double SquareStickRoundness
     {
         get => _squareStickRoundness;
@@ -83,30 +69,6 @@ public sealed class StickControlModeSettingsViewModel :
     }
 
     public double Rotation { get; set; }
-
-    public int Fuzz
-    {
-        get => _fuzz;
-        set => SetProperty(ref _fuzz, value);
-    }
-
-    public bool IsAntiSnapback
-    {
-        get => _isAntiSnapback;
-        set => SetProperty(ref _isAntiSnapback, value);
-    }
-
-    public int AntiSnapbackDelta
-    {
-        get => _antiSnapbackDelta;
-        set => SetProperty(ref _antiSnapbackDelta, value);
-    }
-
-    public int AntiSnapbackTimeout
-    {
-        get => _antiSnapbackTimeout;
-        set => SetProperty(ref _antiSnapbackTimeout, value);
-    }
 
     private void OnShowCustomCurve()
     {
@@ -117,11 +79,7 @@ public sealed class StickControlModeSettingsViewModel :
     protected override void OnPropertyChanged(PropertyChangedEventArgs e)
     {
         base.OnPropertyChanged(e);
-        if (e.PropertyName == nameof(DeadZoneType))
-        {
-            OnPropertyChanged(nameof(IsRadialSet));
-        }
-        else if (e.PropertyName == nameof(DeadZone))
+        if (e.PropertyName == nameof(DeadZone))
         {
             OnPropertyChanged(nameof(DeadZoneConverted));
         }
@@ -162,45 +120,20 @@ public sealed class StickControlModeSettingsViewModel :
         set => DeadZone = _deviceValueConverters.DeadZoneDoubleToInt(value);
     }
 
+    [ObservableProperty]
     private int _antiDeadZone;
 
-    public int AntiDeadZone
-    {
-        get => _antiDeadZone;
-        set => SetProperty(ref _antiDeadZone, value);
-    }
-
+    [ObservableProperty]
     private int _maxZone;
 
-    public int MaxZone
-    {
-        get => _maxZone;
-        set => SetProperty(ref _maxZone, value);
-    }
-
+    [ObservableProperty]
     private int _maxOutput;
 
-    public int MaxOutput
-    {
-        get => _maxOutput;
-        set => SetProperty(ref _maxOutput, value);
-    }
-
+    [ObservableProperty]
     private bool _forceMaxOutput;
 
-    public bool ForceMaxOutput
-    {
-        get => _forceMaxOutput;
-        set => SetProperty(ref _forceMaxOutput, value);
-    }
-
+    [ObservableProperty]
     private int _verticalScale;
-
-    public int VerticalScale
-    {
-        get => _verticalScale;
-        set => SetProperty(ref _verticalScale, value);
-    }
 
     private double _sensitivity;
 
@@ -224,29 +157,14 @@ public sealed class StickControlModeSettingsViewModel :
         set => XDeadZone = _deviceValueConverters.DeadZoneDoubleToInt(value);
     }
 
+    [ObservableProperty]
     private int _xMaxZone;
 
-    public int XMaxZone
-    {
-        get => _xMaxZone;
-        set => SetProperty(ref _xMaxZone, value);
-    }
-
+    [ObservableProperty]
     private int _xAntiDeadZone;
 
-    public int XAntiDeadZone
-    {
-        get => _xAntiDeadZone;
-        set => SetProperty(ref _xAntiDeadZone, value);
-    }
-
+    [ObservableProperty]
     private int _xMaxOutput;
-
-    public int XMaxOutput
-    {
-        get => _xMaxOutput;
-        set => SetProperty(ref _xMaxOutput, value);
-    }
 
     #endregion
 
@@ -260,29 +178,14 @@ public sealed class StickControlModeSettingsViewModel :
         set => YDeadZone = _deviceValueConverters.DeadZoneDoubleToInt(value);
     }
 
+    [ObservableProperty]
     private int _yMaxZone;
 
-    public int YMaxZone
-    {
-        get => _yMaxZone;
-        set => SetProperty(ref _yMaxZone, value);
-    }
-
+    [ObservableProperty]
     private int _yAntiDeadZone;
 
-    public int YAntiDeadZone
-    {
-        get => _yAntiDeadZone;
-        set => SetProperty(ref _yAntiDeadZone, value);
-    }
-
+    [ObservableProperty]
     private int _yMaxOutput;
-
-    public int YMaxOutput
-    {
-        get => _yMaxOutput;
-        set => SetProperty(ref _yMaxOutput, value);
-    }
 
     #endregion
 }

--- a/Vapour.Client.Modules/Profiles/Edit/StickEditViewModel.cs
+++ b/Vapour.Client.Modules/Profiles/Edit/StickEditViewModel.cs
@@ -1,11 +1,11 @@
-﻿using System.ComponentModel;
+﻿using CommunityToolkit.Mvvm.ComponentModel;
 
 using Vapour.Client.Core.ViewModel;
 using Vapour.Shared.Common.Types;
 
 namespace Vapour.Client.Modules.Profiles.Edit;
 
-public sealed class StickEditViewModel :
+public sealed partial class StickEditViewModel :
     ViewModel<IStickEditViewModel>,
     IStickEditViewModel
 {
@@ -13,12 +13,16 @@ public sealed class StickEditViewModel :
 
     private double _flickMinAngleThreshold;
 
+    [ObservableProperty]
     private double _flickRealWorldCalibration;
 
     private double _flickThreshold;
 
     private double _flickTime;
 
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsControlModeSet))]
+    [NotifyPropertyChangedFor(nameof(IsFlickStickSet))]
     private StickMode _outputSettings;
 
     public StickEditViewModel(IViewModelFactory viewModelFactory)
@@ -35,19 +39,7 @@ public sealed class StickEditViewModel :
             await _viewModelFactory.Create<IStickControlModeSettingsViewModel, IStickControlModeSettingsView>();
     }
 
-    public StickMode OutputSettings
-    {
-        get => _outputSettings;
-        set => SetProperty(ref _outputSettings, value);
-    }
-
     public IStickControlModeSettingsViewModel ControlModeSettings { get; private set; }
-
-    public double FlickRealWorldCalibration
-    {
-        get => _flickRealWorldCalibration;
-        set => SetProperty(ref _flickRealWorldCalibration, value);
-    }
 
     public double FlickThreshold
     {
@@ -65,16 +57,6 @@ public sealed class StickEditViewModel :
     {
         get => _flickMinAngleThreshold;
         set => SetProperty(ref _flickMinAngleThreshold, Math.Round(value, 1));
-    }
-
-    protected override void OnPropertyChanged(PropertyChangedEventArgs e)
-    {
-        base.OnPropertyChanged(e);
-        if (e.PropertyName == nameof(OutputSettings))
-        {
-            OnPropertyChanged(nameof(IsControlModeSet));
-            OnPropertyChanged(nameof(IsFlickStickSet));
-        }
     }
 
     protected override void Dispose(bool disposing)

--- a/Vapour.Client.Modules/Profiles/Edit/TriggerButtonsEditViewModel.cs
+++ b/Vapour.Client.Modules/Profiles/Edit/TriggerButtonsEditViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using System.ComponentModel;
 using System.Diagnostics;
 
+using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 
 using Vapour.Client.Core;
@@ -10,28 +11,36 @@ using Vapour.Shared.Common.Types;
 
 namespace Vapour.Client.Modules.Profiles.Edit;
 
-public sealed class TriggerButtonsEditViewModel :
+public sealed partial class TriggerButtonsEditViewModel :
     ViewModel<ITriggerButtonsEditViewModel>,
     ITriggerButtonsEditViewModel
 {
     private readonly IDeviceValueConverters _deviceValueConverters;
 
+    [ObservableProperty]
     private int _antiDeadZone;
 
+    [ObservableProperty]
     private BezierCurve _customCurve;
 
+    [ObservableProperty]
     private int _hipFireDelay;
 
+    [ObservableProperty]
     private int _maxOutput;
 
+    [ObservableProperty]
     private int _maxZone;
 
+    [ObservableProperty]
     private CurveMode _outputCurve;
 
     private double _sensitivity;
 
+    [ObservableProperty]
     private TriggerEffects _triggerEffect;
 
+    [ObservableProperty]
     private TwoStageTriggerMode _twoStageTriggerMode;
 
     public TriggerButtonsEditViewModel(IDeviceValueConverters deviceValueConverters)
@@ -52,60 +61,12 @@ public sealed class TriggerButtonsEditViewModel :
         set => DeadZone = _deviceValueConverters.DeadZoneDoubleToInt(value);
     }
 
-    public int AntiDeadZone
-    {
-        get => _antiDeadZone;
-        set => SetProperty(ref _antiDeadZone, value);
-    }
-
-    public int MaxZone
-    {
-        get => _maxZone;
-        set => SetProperty(ref _maxZone, value);
-    }
-
-    public int MaxOutput
-    {
-        get => _maxOutput;
-        set => SetProperty(ref _maxOutput, value);
-    }
-
     public double Sensitivity
     {
         get => _sensitivity;
         set => SetProperty(ref _sensitivity, Math.Round(value, 1));
         //Math round needed because wpf slider control when binding to double and tick increment
         //of 0.1 when it hits values like 1.2 and 2.2 it sends 1.20000000002 or something like that
-    }
-
-    public int HipFireDelay
-    {
-        get => _hipFireDelay;
-        set => SetProperty(ref _hipFireDelay, value);
-    }
-
-    public CurveMode OutputCurve
-    {
-        get => _outputCurve;
-        set => SetProperty(ref _outputCurve, value);
-    }
-
-    public BezierCurve CustomCurve
-    {
-        get => _customCurve;
-        set => SetProperty(ref _customCurve, value);
-    }
-
-    public TwoStageTriggerMode TwoStageTriggerMode
-    {
-        get => _twoStageTriggerMode;
-        set => SetProperty(ref _twoStageTriggerMode, value);
-    }
-
-    public TriggerEffects TriggerEffect
-    {
-        get => _triggerEffect;
-        set => SetProperty(ref _triggerEffect, value);
     }
 
     private void OnShowCustomCurve()

--- a/Vapour.Client.Modules/Profiles/ProfileListItemViewModel.cs
+++ b/Vapour.Client.Modules/Profiles/ProfileListItemViewModel.cs
@@ -2,6 +2,8 @@
 
 using AutoMapper;
 
+using CommunityToolkit.Mvvm.ComponentModel;
+
 using Vapour.Client.Core.ViewModel;
 using Vapour.Shared.Configuration.Profiles;
 using Vapour.Shared.Configuration.Profiles.Schema;
@@ -9,37 +11,37 @@ using Vapour.Shared.Configuration.Profiles.Types;
 
 namespace Vapour.Client.Modules.Profiles;
 
-public sealed class ProfileListItemViewModel :
+public sealed partial class ProfileListItemViewModel :
     ViewModel<IProfileListItemViewModel>,
     IProfileListItemViewModel
 {
-    private readonly IMapper mapper;
-    private IProfile profile;
+    private readonly IMapper _mapper;
+    private IProfile _profile;
 
     public ProfileListItemViewModel(IMapper mapper)
     {
-        this.mapper = mapper;
+        _mapper = mapper;
     }
 
     public void SetProfile(IProfile profile)
     {
-        this.profile = profile;
-        this.profile.ProfilePropertyChanged += Profile_ProfilePropertyChanged;
+        _profile = profile;
+        _profile.ProfilePropertyChanged += Profile_ProfilePropertyChanged;
 
-        mapper.Map(profile, this);
+        _mapper.Map(profile, this);
     }
 
     private void Profile_ProfilePropertyChanged(object sender, ProfilePropertyChangedEventArgs e)
     {
-        mapper.Map(profile, this);
+        _mapper.Map(_profile, this);
     }
 
     protected override void Dispose(bool disposing)
     {
         if (disposing)
         {
-            profile.ProfilePropertyChanged -= Profile_ProfilePropertyChanged;
-            profile = null;
+            _profile.ProfilePropertyChanged -= Profile_ProfilePropertyChanged;
+            _profile = null;
         }
 
         base.Dispose(disposing);
@@ -47,61 +49,26 @@ public sealed class ProfileListItemViewModel :
 
     #region Properties
 
-    private Guid id;
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(NotIsDefaultProfile))]
+    private Guid _id;
 
-    public Guid Id
-    {
-        get => id;
-        private set => SetProperty(ref id, value);
-    }
+    [ObservableProperty]
+    private string _name;
 
-    private string name;
+    [ObservableProperty]
+    private string _outputControllerType;
 
-    public string Name
-    {
-        get => name;
-        private set => SetProperty(ref name, value);
-    }
+    [ObservableProperty]
+    private SolidColorBrush _lightbarColor;
 
-    private string outputControllerType;
+    [ObservableProperty]
+    private string _touchpadMode;
 
-    public string OutputControllerType
-    {
-        get => outputControllerType;
-        private set => SetProperty(ref outputControllerType, value);
-    }
+    [ObservableProperty]
+    private string _gyroMode;
 
-    private SolidColorBrush lightbarColor;
-
-    public SolidColorBrush LightbarColor
-    {
-        get => lightbarColor;
-        private set => SetProperty(ref lightbarColor, value);
-    }
-
-    private string touchpadMode;
-
-    public string TouchpadMode
-    {
-        get => touchpadMode;
-        private set => SetProperty(ref touchpadMode, value);
-    }
-
-    private string gyroMode;
-
-    public string GyroMode
-    {
-        get => gyroMode;
-        private set => SetProperty(ref gyroMode, value);
-    }
-
-    public bool NotIsDefaultProfile
-    {
-        get
-        {
-            return Id != Constants.DefaultProfileId;
-        }
-    }
+    public bool NotIsDefaultProfile => Id != Constants.DefaultProfileId;
 
     #endregion
 }

--- a/Vapour.Client.Modules/Settings/SettingsViewModel.cs
+++ b/Vapour.Client.Modules/Settings/SettingsViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 
+using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 
 using MaterialDesignThemes.Wpf;
@@ -17,13 +18,16 @@ namespace Vapour.Client.Modules.Settings;
 [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
 [SuppressMessage("ReSharper", "UnusedMember.Global")]
 [SuppressMessage("ReSharper", "ClassNeverInstantiated.Global")]
-public sealed class SettingsViewModel : NavigationTabViewModel<ISettingsViewModel, ISettingsView>, ISettingsViewModel
+public sealed partial class SettingsViewModel : NavigationTabViewModel<ISettingsViewModel, ISettingsView>, ISettingsViewModel
 {
     private readonly ISystemServiceClient _systemServiceClient;
 
+    [ObservableProperty]
     private bool _isFilterDriverEnabled;
 
+    [ObservableProperty]
     private bool _isFilterDriverInstalled;
+
     private bool _isInitializing = true;
 
     public SettingsViewModel(ISystemServiceClient systemServiceClient)
@@ -35,25 +39,7 @@ public sealed class SettingsViewModel : NavigationTabViewModel<ISettingsViewMode
 
     public RelayCommand InstallFilterDriverCommand { get; }
 
-    public bool IsFilterDriverEnabled
-    {
-        get => _isFilterDriverEnabled;
-        set => SetProperty(ref _isFilterDriverEnabled, value);
-    }
-
-    public bool IsFilterDriverInstalled
-    {
-        get => _isFilterDriverInstalled;
-        private set => SetProperty(ref _isFilterDriverInstalled, value);
-    }
-
-    public string InstallDriverContent
-    {
-        get
-        {
-            return IsFilterDriverInstalled ? "Uninstall Filter Driver" : "Install Filter Driver";
-        }
-    }
+    public string InstallDriverContent => IsFilterDriverInstalled ? "Uninstall Filter Driver" : "Install Filter Driver";
 
     public override async Task Initialize()
     {

--- a/Vapour.Client.TrayApplication/TrayViewModel.cs
+++ b/Vapour.Client.TrayApplication/TrayViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using System.ComponentModel;
 using System.Diagnostics;
 
+using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 
 using Vapour.Client.Core.ViewModel;
@@ -10,18 +11,18 @@ using Vapour.Server.System;
 
 namespace Vapour.Client.TrayApplication;
 
-public interface ITrayViewModel : IViewModel<ITrayViewModel>
-{
-}
+public interface ITrayViewModel : IViewModel<ITrayViewModel>;
 
-public class TrayViewModel : ViewModel<ITrayViewModel>, ITrayViewModel
+public partial class TrayViewModel : ViewModel<ITrayViewModel>, ITrayViewModel
 {
     private readonly IProfileServiceClient _profileServiceClient;
     private readonly ISystemServiceClient _systemServiceClient;
     private readonly IViewModelFactory _viewModelFactory;
 
+    [ObservableProperty]
     private string _hostButtonText;
 
+    [ObservableProperty]
     private bool _isHostRunning;
 
     public TrayViewModel(IProfileServiceClient profileServiceClient, IViewModelFactory viewModelFactory,
@@ -32,18 +33,6 @@ public class TrayViewModel : ViewModel<ITrayViewModel>, ITrayViewModel
         _systemServiceClient = systemServiceClient;
         ShowClientCommand = new RelayCommand(OnShowClient);
         ChangeHostStateCommand = new RelayCommand(ChangeHostState);
-    }
-
-    public bool IsHostRunning
-    {
-        get => _isHostRunning;
-        set => SetProperty(ref _isHostRunning, value);
-    }
-
-    public string HostButtonText
-    {
-        get => _hostButtonText;
-        set => SetProperty(ref _hostButtonText, value);
     }
 
     public IRelayCommand ShowClientCommand { get; }

--- a/Vapour.Client.TrayApplication/TrayViewModel.cs
+++ b/Vapour.Client.TrayApplication/TrayViewModel.cs
@@ -1,5 +1,4 @@
-﻿using System.ComponentModel;
-using System.Diagnostics;
+﻿using System.Diagnostics;
 
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -19,10 +18,10 @@ public partial class TrayViewModel : ViewModel<ITrayViewModel>, ITrayViewModel
     private readonly ISystemServiceClient _systemServiceClient;
     private readonly IViewModelFactory _viewModelFactory;
 
-    [ObservableProperty]
-    private string _hostButtonText;
+    public string HostButtonText => IsHostRunning ? "Stop" : "Start";
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HostButtonText))]
     private bool _isHostRunning;
 
     public TrayViewModel(IProfileServiceClient profileServiceClient, IViewModelFactory viewModelFactory,
@@ -68,15 +67,6 @@ public partial class TrayViewModel : ViewModel<ITrayViewModel>, ITrayViewModel
         else
         {
             await _systemServiceClient.StartHost();
-        }
-    }
-
-    protected override void OnPropertyChanged(PropertyChangedEventArgs e)
-    {
-        base.OnPropertyChanged(e);
-        if (e.PropertyName == nameof(IsHostRunning))
-        {
-            HostButtonText = IsHostRunning ? "Stop" : "Start";
         }
     }
 }

--- a/Vapour.Shared.Common.Interfaces/Core/Constants.cs
+++ b/Vapour.Shared.Common.Interfaces/Core/Constants.cs
@@ -51,7 +51,7 @@ public static class Constants
 
     public const string HidHideGuideUri = "https://docs.ds4windows.app/troubleshooting/hidhide-troubleshoot/";
 
-    public const string HttpPort = "50317";
+    public const string HttpPort = "8837";
     
     public const string HttpUrl = $"http://localhost:{HttpPort}";
     

--- a/Vapour.Shared.Common.Interfaces/Core/Constants.cs
+++ b/Vapour.Shared.Common.Interfaces/Core/Constants.cs
@@ -51,7 +51,7 @@ public static class Constants
 
     public const string HidHideGuideUri = "https://docs.ds4windows.app/troubleshooting/hidhide-troubleshoot/";
 
-    public const string HttpPort = "8837";
+    public const string HttpPort = "50317";
     
     public const string HttpUrl = $"http://localhost:{HttpPort}";
     


### PR DESCRIPTION
Changed `SetProperty`/`OnPropertyChanged` properties to use `CommunityToolkit.Mvvm`'s [`[ObservableProperty]` source-generation](https://learn.microsoft.com/en-us/dotnet/communitytoolkit/mvvm/generators/observableproperty) where it's trivial.

Also updated couple private fields I came across to follow .editorconfig naming-convention.

### Changes
* [Use [ObservableProperty] in InputSource view-models](https://github.com/CircumSpector/DS4Windows/commit/035bdbe1ad81c17492b954ea746e859f913c0731)
* [Use [ObservableProperty] in the Profile view-models](https://github.com/CircumSpector/DS4Windows/commit/16df601a082c5408de5aa7c259f7d9ef2eb7c86f)
* [Use [ObservableProperty] in the remaining view-models.](https://github.com/CircumSpector/DS4Windows/commit/16c88195b488cb99eacfc250c8c8d5ed2228db4d)
* [Simplify TrayViewModel HostButtonText binding](https://github.com/CircumSpector/DS4Windows/pull/413/commits/1f8d322242d5f44136159419fdaf101f5f81bbbe)

I plan to follow this up with [`[RelayCommand]` source-generation.](https://learn.microsoft.com/en-us/dotnet/communitytoolkit/mvvm/generators/relaycommand)