### PR TITLE
fix: use control pipe for BT output on Realtek adapters

### DIFF
--- a/Vapour.Shared.Devices/Services/Reporting/OutputReportProcessor.cs
+++ b/Vapour.Shared.Devices/Services/Reporting/OutputReportProcessor.cs
@@ -83,7 +83,10 @@ public sealed class OutputReportProcessor : IOutputReportProcessor
             while (!_outputReportCancellationToken.IsCancellationRequested)
             {
                 byte[] buffer = await _device.ReadOutputReport(_outputReportCancellationToken.Token);
-                _device.SourceDevice.WriteOutputReportViaInterrupt(buffer, 500);
+                if (_device.Connection == ConnectionType.Bluetooth)
+                    _device.SourceDevice.WriteOutputReportViaControl(buffer);
+                else
+                    _device.SourceDevice.WriteOutputReportViaInterrupt(buffer, 500);
                 OutputReportsSentCounter.Add(1);
             }
         }


### PR DESCRIPTION
## Problem

Some Bluetooth adapters (notably Realtek RTL8761B, e.g. TP-Link UB500) silently accept `WriteFile` (interrupt pipe) output reports with any report ID, returning success without delivering the data to the controller. This causes DualShock 4 lightbar and rumble to silently fail over Bluetooth on affected hardware.

## Root Cause

`OutputReportProcessor.SendOutputReportLoop` unconditionally uses `WriteOutputReportViaInterrupt` (which calls `WriteFile`). On Realtek BT adapters, the driver accepts the write and returns success, but the data never reaches the controller.

## Fix

Use `WriteOutputReportViaControl` (`HidD_SetOutputReport`) for Bluetooth connections. This uses the HID control pipe which works reliably on all tested adapters. USB connections continue using the interrupt pipe.

## Testing

Tested with:
- DualShock 4 v1 (CUH-ZCT1) over Bluetooth
- TP-Link UB500 adapter (Realtek RTL8761B)
- Windows 11

Confirmed: `HidD_SetOutputReport` delivers lightbar and rumble data correctly, while `WriteFile` silently drops it on this adapter.